### PR TITLE
Fix queue cleaner behavior when over 1000 queues

### DIFF
--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -30,7 +30,7 @@ func main() {
 			return
 		} else {
 			log.Printf("Deleted %d queues, running again as aws limits queues returned to 1000", count)
-			time.Sleep(time.Second * 5)
+			time.Sleep(time.Second * 60)
 		}
 	}
 }
@@ -50,6 +50,7 @@ func deleteInactiveQueues(sess *session.Session, parallel int) (uint64, error) {
 	for i := 0; i < parallel; i++ {
 		go func(total int) {
 			for queue := range queuesCh {
+				atomic.AddUint64(&count, 1)
 				log.Printf("Deleting %s (%d of %d)", queue, count, total)
 				err = deleteQueue(sess, queue)
 				wg.Done()
@@ -62,7 +63,6 @@ func deleteInactiveQueues(sess *session.Session, parallel int) (uint64, error) {
 					errCh <- err
 					return
 				}
-				atomic.AddUint64(&count, 1)
 			}
 		}(len(queues))
 	}


### PR DESCRIPTION
SQS queue deletion is eventually consistent and 5 seconds isn't enough to not see deleted queues.

The process decides to stop when `deleteInactiveQueues` returns 0, but the function only increments count when a queue deletion is successful. The function really should return how many inactive queues were found, not how many were successfully deleted.

These two bugs combined mean that the process deletes queues in the first batch of 1000, returns a positive count, waits 5 seconds, the queries again and gets the exact same queues. Because attempting to delete an already deleted queue (among other possible errors) doesn't increment the count, it returns a count of 0 and stops, even though there are potentially thousands of other undeleted queues.