### PR TITLE
Respect http timeouts and context with termination times

### DIFF
--- a/spot.go
+++ b/spot.go
@@ -29,7 +29,7 @@ func pollSpotTermination(ctx context.Context) chan time.Time {
 			case <-ctx.Done():
 				return
 			case <-time.NewTicker(time.Second * 5).C:
-				timeout, hasTimeout, err := getTerminationTime(ctx)
+				timeout, hasTimeout, err := getTerminationTime(ctx, metadataURLTerminationTime)
 				if err != nil {
 					log.WithError(err).Info("Failed to get spot termination time")
 					continue
@@ -45,8 +45,8 @@ func pollSpotTermination(ctx context.Context) chan time.Time {
 }
 
 // getTermination time returns a termination time, whether one exists and any error
-func getTerminationTime(ctx context.Context) (time.Time, bool, error) {
-	req, err := http.NewRequest(http.MethodGet, metadataURLTerminationTime, nil)
+func getTerminationTime(ctx context.Context, metadataURL string) (time.Time, bool, error) {
+	req, err := http.NewRequest(http.MethodGet, metadataURL, nil)
 	if err != nil {
 		return time.Time{}, false, err
 	}

--- a/spot.go
+++ b/spot.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -23,42 +24,58 @@ func pollSpotTermination(ctx context.Context) chan time.Time {
 	go func() {
 		// Close channel before returning since this (goroutine) is the sending side.
 		defer close(ch)
-		retry := time.NewTicker(time.Second * 5).C
-	Loop:
 		for {
 			select {
 			case <-ctx.Done():
-				break Loop
-			case <-retry:
-				res, err := http.Get(metadataURLTerminationTime)
+				return
+			case <-time.NewTicker(time.Second * 5).C:
+				timeout, hasTimeout, err := getTerminationTime(ctx)
 				if err != nil {
-					log.WithError(err).Info("Failed to query metadata service")
+					log.WithError(err).Info("Failed to get spot termination time")
 					continue
 				}
-				defer res.Body.Close()
-
-				// will return 200 OK with termination notice
-				if res.StatusCode != http.StatusOK {
-					continue
+				if hasTimeout {
+					ch <- timeout
 				}
-
-				body, err := ioutil.ReadAll(res.Body)
-				if err != nil {
-					log.WithError(err).Info("Failed to read response from metadata service")
-					continue
-				}
-
-				// if 200 OK, expect a body like 2015-01-05T18:02:00Z
-				t, err := time.Parse(terminationTimeFormat, string(body))
-				if err != nil {
-					log.WithError(err).Info("Failed to parse time in termination notice")
-					continue
-				}
-
-				ch <- t
 			}
 		}
 	}()
 
 	return ch
+}
+
+// getTermination time returns a termination time, whether one exists and any error
+func getTerminationTime(ctx context.Context) (time.Time, bool, error) {
+	req, err := http.NewRequest(http.MethodGet, metadataURLTerminationTime, nil)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	client := http.Client{
+		Timeout: time.Second * 5,
+	}
+	res, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return time.Time{}, false, err
+	}
+
+	defer res.Body.Close()
+
+	// will return 200 OK with termination notice
+	if res.StatusCode != http.StatusOK {
+		return time.Time{}, false, nil
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return time.Time{}, true, fmt.Errorf("Failed to read response from metadata service: %v", err)
+	}
+
+	// if 200 OK, expect a body like 2015-01-05T18:02:00Z
+	t, err := time.Parse(terminationTimeFormat, string(body))
+	if err != nil {
+		return time.Time{}, true, fmt.Errorf("Failed to parse time in termination notice: %v", err)
+	}
+
+	return t, true, nil
 }

--- a/spot_test.go
+++ b/spot_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGettingTerminationTimesWhenAvailable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("2015-01-05T18:02:00Z"))
+	}))
+	defer ts.Close()
+
+	termTime, hasTermTime, err := getTerminationTime(context.TODO(), ts.URL)
+
+	if !hasTermTime {
+		t.Fatalf("Expected termination time")
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTime := time.Date(2015, time.January, 5, 18, 2, 0, 0, time.UTC)
+
+	if !termTime.Equal(expectedTime) {
+		t.Fatalf("Expected %v, got %v", expectedTime, termTime)
+	}
+}
+
+func TestGettingTerminationTimesWhenUnavailable(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	termTime, hasTermTime, err := getTerminationTime(context.TODO(), ts.URL)
+
+	if hasTermTime {
+		t.Fatalf("Expected no termination time when unavailable")
+	}
+
+	if err != nil {
+		t.Fatalf("Expected no error when unavailable: %#v", err)
+	}
+
+	if !termTime.IsZero() {
+		t.Fatalf("Expected zero time, got %v", termTime)
+	}
+}
+
+func TestGettingTerminationTimesWhenCancelled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Microsecond*10)
+	defer cancel()
+
+	termTime, hasTermTime, err := getTerminationTime(ctx, `https://httpbin.org/delay/3`)
+
+	if hasTermTime {
+		t.Fatalf("Expected no termination time when cancelled")
+	}
+
+	if err == nil {
+		t.Fatalf("Expected an error when cancelled")
+	}
+
+	if !termTime.IsZero() {
+		t.Fatalf("Expected zero time, got %v", termTime)
+	}
+}


### PR DESCRIPTION
As per #34, we are leaking sockets. 

This is another take on refactoring the spot termination time polling that respects the `context.Context` that we've introduced and also uses an http client with timeouts. 

Thoughts @itsdalmo? 