### PR TITLE
Update systemd unit with better defaults for Amazon Linux

### DIFF
--- a/init/systemd/lifecycled.unit
+++ b/init/systemd/lifecycled.unit
@@ -1,7 +1,13 @@
 [Unit]
 Description=Autoscale Lifecycle Daemon
+Requires=network-online.target
+After=network-online.target
 
 [Service]
+Type=simple
+Restart=on-failure
+RestartSec=1m
+TimeoutStopSec=5m
 EnvironmentFile=/etc/lifecycled
 ExecStart=/usr/bin/lifecycled
 

--- a/init/systemd/lifecycled.unit
+++ b/init/systemd/lifecycled.unit
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 Restart=on-failure
-RestartSec=1m
+RestartSec=30s
 TimeoutStopSec=5m
 EnvironmentFile=/etc/lifecycled
 ExecStart=/usr/bin/lifecycled


### PR DESCRIPTION
As discussed in https://github.com/buildkite/lifecycled/pull/33, this brings in some better defaults for the systemd unit we suggest:

* `After=network-online.target`: specifies that lifecycled should only be started after the network is online (and shut down before the network).
* `Restart=on-failure`: Restart lifecycled if it exits with an error. I chose this over always because (in the future) it allows us to have a "happy path" which shuts down lifecycled immediately after completing the lifecycle hook, instead of waiting for a SIGTERM. In this case we don't want it to restart again.
* `RestartSec=1m`: Since the queue should always be cleaned on exit, it cannot be recreated within 1min of being deleted, so there is no point in restarting before the 1min is up.
* `TimeoutStopSec=5m`: Added because at least on Amazon Linux 2 I experienced that manual interrupts (systemctl stop lifecycled.service) would immediately log that the SIGTERM had timed out and issue a SIGKILL. This happened even though the default timeout should be 90 seconds. 

Thanks @itsdalmo 