### PR TITLE
Rewrite as lifecycle and spot monitors

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -18,9 +18,8 @@ type Daemon struct {
 }
 
 type TerminationNotice struct {
-	Done  chan struct{}
-	Error chan error
-	Args  []string
+	Done chan struct{}
+	Args []string
 }
 
 // Start the daemon.
@@ -69,7 +68,6 @@ func (d *Daemon) Start(ctx context.Context) error {
 			log.Info("Received termination notice, executing handler")
 			if err := executeHandler(subctx, d.Handler, term.Args); err != nil {
 				log.WithError(err).Info("Handler finished with an error")
-				term.Error <- err
 			} else {
 				log.Info("Handler finished successfully")
 				term.Done <- struct{}{}

--- a/daemon.go
+++ b/daemon.go
@@ -2,203 +2,62 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"os"
-	"os/exec"
-	"time"
+	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
-	"github.com/aws/aws-sdk-go/service/sqs"
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	heartbeatFrequency = time.Second * 10
-)
-
-type Envelope struct {
-	Type    string    `json:"Type"`
-	Subject string    `json:"Subject"`
-	Time    time.Time `json:"Time"`
-	Message string    `json:"Message"`
-}
-
-type AutoscalingMessage struct {
-	Time        time.Time `json:"Time"`
-	GroupName   string    `json:"AutoScalingGroupName"`
-	InstanceID  string    `json:"EC2InstanceId"`
-	ActionToken string    `json:"LifecycleActionToken"`
-	Transition  string    `json:"LifecycleTransition"`
-	HookName    string    `json:"LifecycleHookName"`
-}
-
 type Daemon struct {
-	InstanceID  string
-	Queue       *Queue
-	AutoScaling *autoscaling.AutoScaling
-	Handler     *os.File
+	LifecycleMonitor *LifecycleMonitor
+	SpotMonitor      *SpotMonitor
 }
 
 // Start the daemon.
 func (d *Daemon) Start(ctx context.Context) error {
-	if err := d.Queue.Create(); err != nil {
-		return err
+	var wg sync.WaitGroup
+	var errCh = make(chan error)
+
+	// Process lifecycle events
+	if d.LifecycleMonitor != nil {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			errCh <- d.LifecycleMonitor.Run(ctx)
+		}()
 	}
-	defer func() {
-		if err := d.Queue.Delete(); err != nil {
-			log.WithError(err).Error("Failed to delete queue")
-		}
-	}()
 
-	if err := d.Queue.Subscribe(); err != nil {
-		return err
+	// Process spot notifications
+	if d.SpotMonitor != nil {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			errCh <- d.SpotMonitor.Run(ctx)
+		}()
 	}
-	defer func() {
-		if err := d.Queue.Unsubscribe(); err != nil {
-			log.WithError(err).Error("Failed to unsubscribe from sns topic")
-		}
-	}()
 
-	ch := make(chan *sqs.Message)
-
+	// Wait for monitors to have finished and then close the error channel
 	go func() {
-		for m := range ch {
-			var env Envelope
-			var msg AutoscalingMessage
-
-			// unmarshal outer layer
-			if err := json.Unmarshal([]byte(*m.Body), &env); err != nil {
-				log.WithError(err).Info("Failed to unmarshal envelope")
-				continue
-			}
-
-			log.WithFields(log.Fields{
-				"type":    env.Type,
-				"subject": env.Subject,
-			}).Debugf("Received an SQS message")
-
-			// unmarshal inner layer
-			if err := json.Unmarshal([]byte(env.Message), &msg); err != nil {
-				log.WithError(err).Info("Failed to unmarshal autoscaling message")
-				continue
-			}
-
-			if msg.InstanceID != d.InstanceID {
-				log.WithFields(log.Fields{
-					"was":    msg.InstanceID,
-					"wanted": d.InstanceID,
-				}).Debugf("Skipping autoscaling event, doesn't match instance id")
-				continue
-			}
-
-			d.handleMessage(ctx, msg)
-		}
+		wg.Wait()
+		close(errCh)
 	}()
 
-	spotTerminations := pollSpotTermination(ctx)
-	go func() {
-		for notice := range spotTerminations {
-			log.Infof("Got a spot instance termination notice: %v", notice)
+	var errs []error
 
-			log.Info("Executing handler")
-			timer := time.Now()
-			err := executeHandler(ctx, d.Handler, []string{terminationTransition, d.InstanceID})
-			executeCtx := log.WithFields(log.Fields{
-				"duration": time.Now().Sub(timer),
-			})
+	// Wait for either an error or nil back from each monitor. Blocks until
+	// the above wait fires
+	for err := range errCh {
+		log.WithFields(log.Fields{"err": err}).Debugf("Monitor finished")
 
-			if err != nil {
-				executeCtx.WithError(err).Error("Handler script failed")
-				return
-			}
-
-			executeCtx.Info("Handler finished successfully")
-
+		if err != nil {
+			errs = append(errs, err)
 		}
-	}()
-
-	log.Info("Listening for lifecycle notifications")
-	return d.Queue.Receive(ctx, ch)
-}
-
-func (d *Daemon) handleMessage(ctx context.Context, m AutoscalingMessage) {
-	logCtx := log.WithFields(log.Fields{
-		"transition": m.Transition,
-		"instanceid": m.InstanceID,
-	})
-
-	hbt := time.NewTicker(heartbeatFrequency)
-	go func() {
-		for range hbt.C {
-			logCtx.Debug("Sending heartbeat")
-			if err := sendHeartbeat(d.AutoScaling, m); err != nil {
-				logCtx.WithError(err).Error("Heartbeat failed")
-			}
-		}
-	}()
-
-	handlerLogCtx := log.WithFields(log.Fields{
-		"transition": m.Transition,
-		"instanceid": m.InstanceID,
-		"handler":    d.Handler.Name(),
-	})
-
-	handlerLogCtx.Info("Executing handler")
-	timer := time.Now()
-
-	err := executeHandler(ctx, d.Handler, []string{m.Transition, m.InstanceID})
-	executeLogCtx := handlerLogCtx.WithFields(log.Fields{
-		"duration": time.Now().Sub(timer),
-	})
-	hbt.Stop()
-
-	if err != nil {
-		executeLogCtx.WithError(err).Error("Handler script failed")
-		return
 	}
 
-	executeLogCtx.Info("Handler finished successfully")
-
-	if err = completeLifecycle(d.AutoScaling, m); err != nil {
-		logCtx.WithError(err).Error("Failed to complete lifecycle action")
-		return
+	if len(errs) > 0 {
+		return errs[0]
 	}
 
-	logCtx.Info("Lifecycle action completed successfully")
-}
-
-func executeHandler(ctx context.Context, command *os.File, args []string) error {
-	cmd := exec.CommandContext(ctx, command.Name(), args...)
-	cmd.Env = os.Environ()
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func sendHeartbeat(svc *autoscaling.AutoScaling, m AutoscalingMessage) error {
-	_, err := svc.RecordLifecycleActionHeartbeat(&autoscaling.RecordLifecycleActionHeartbeatInput{
-		AutoScalingGroupName: aws.String(m.GroupName),
-		LifecycleHookName:    aws.String(m.HookName),
-		InstanceId:           aws.String(m.InstanceID),
-		LifecycleActionToken: aws.String(m.ActionToken),
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func completeLifecycle(svc *autoscaling.AutoScaling, m AutoscalingMessage) error {
-	_, err := svc.CompleteLifecycleAction(&autoscaling.CompleteLifecycleActionInput{
-		AutoScalingGroupName:  aws.String(m.GroupName),
-		LifecycleHookName:     aws.String(m.HookName),
-		InstanceId:            aws.String(m.InstanceID),
-		LifecycleActionToken:  aws.String(m.ActionToken),
-		LifecycleActionResult: aws.String("CONTINUE"),
-	})
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -46,6 +46,8 @@ type LifecycleMonitor struct {
 func (l *LifecycleMonitor) Run(ctx context.Context) error {
 	var cleanup sync.Once
 	cleanupFunc := func() {
+		log.Debug("Cleaning up lifecycle queue")
+
 		if err := l.Queue.Delete(); err != nil {
 			log.WithError(err).Error("Failed to delete queue")
 		}
@@ -54,6 +56,8 @@ func (l *LifecycleMonitor) Run(ctx context.Context) error {
 			log.WithError(err).Error("Failed to unsubscribe from sns topic")
 		}
 	}
+
+	log.Debug("Creating lifecycle queue")
 
 	// create an SQS queue for the upstream SNS topic
 	if err := l.Queue.Create(); err != nil {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/aws/aws-sdk-go/service/sqs"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	heartbeatFrequency = time.Second * 10
+)
+
+type envelope struct {
+	Type    string    `json:"Type"`
+	Subject string    `json:"Subject"`
+	Time    time.Time `json:"Time"`
+	Message string    `json:"Message"`
+}
+
+type autoscalingMessage struct {
+	Time        time.Time `json:"Time"`
+	GroupName   string    `json:"AutoScalingGroupName"`
+	InstanceID  string    `json:"EC2InstanceId"`
+	ActionToken string    `json:"LifecycleActionToken"`
+	Transition  string    `json:"LifecycleTransition"`
+	HookName    string    `json:"LifecycleHookName"`
+}
+
+type LifecycleMonitor struct {
+	InstanceID  string
+	Queue       *Queue
+	AutoScaling *autoscaling.AutoScaling
+	Handler     *os.File
+}
+
+func (l *LifecycleMonitor) Run(ctx context.Context) error {
+	var cleanup sync.Once
+	cleanupFunc := func() {
+		if err := l.Queue.Delete(); err != nil {
+			log.WithError(err).Error("Failed to delete queue")
+		}
+
+		if err := l.Queue.Unsubscribe(); err != nil {
+			log.WithError(err).Error("Failed to unsubscribe from sns topic")
+		}
+	}
+
+	// create an SQS queue for the upstream SNS topic
+	if err := l.Queue.Create(); err != nil {
+		return err
+	}
+
+	defer cleanup.Do(cleanupFunc)
+
+	// connect the SQS queue to the SNS topic
+	if err := l.Queue.Subscribe(); err != nil {
+		return err
+	}
+
+	ch := make(chan *sqs.Message)
+
+	go func() {
+		log.Info("Listening for lifecycle notifications")
+		if err := l.Queue.Receive(ctx, ch); err != nil {
+			log.WithError(err).Error("Failed to receive from queue")
+		}
+	}()
+
+	for m := range ch {
+		var env envelope
+		var msg autoscalingMessage
+
+		// unmarshal outer layer
+		if err := json.Unmarshal([]byte(*m.Body), &env); err != nil {
+			log.WithError(err).Info("Failed to unmarshal envelope")
+			continue
+		}
+
+		log.WithFields(log.Fields{
+			"type":    env.Type,
+			"subject": env.Subject,
+		}).Debugf("Received an SQS message")
+
+		// unmarshal inner layer
+		if err := json.Unmarshal([]byte(env.Message), &msg); err != nil {
+			log.WithError(err).Info("Failed to unmarshal autoscaling message")
+			continue
+		}
+
+		if msg.InstanceID != l.InstanceID {
+			log.WithFields(log.Fields{
+				"was":    msg.InstanceID,
+				"wanted": l.InstanceID,
+			}).Debugf("Skipping autoscaling event, doesn't match instance id")
+			continue
+		}
+
+		l.handleMessage(msg, func() {
+			cleanup.Do(cleanupFunc)
+		})
+	}
+
+	return nil
+}
+
+func (l *LifecycleMonitor) handleMessage(m autoscalingMessage, cleanup func()) {
+	ctx := log.WithFields(log.Fields{
+		"transition": m.Transition,
+		"instanceid": m.InstanceID,
+	})
+
+	hbt := time.NewTicker(heartbeatFrequency)
+	go func() {
+		for range hbt.C {
+			ctx.Debug("Sending heartbeat")
+			if err := sendHeartbeat(l.AutoScaling, m); err != nil {
+				ctx.WithError(err).Error("Heartbeat failed")
+			}
+		}
+	}()
+
+	handlerCtx := log.WithFields(log.Fields{
+		"transition": m.Transition,
+		"instanceid": m.InstanceID,
+		"handler":    l.Handler.Name(),
+	})
+
+	handlerCtx.Info("Executing handler")
+	timer := time.Now()
+
+	cmd := exec.Command(l.Handler.Name(), m.Transition, m.InstanceID)
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+
+	executeCtx := handlerCtx.WithFields(log.Fields{
+		"duration": time.Now().Sub(timer),
+	})
+	hbt.Stop()
+
+	if err != nil {
+		executeCtx.WithError(err).Error("Handler script failed")
+		return
+	}
+
+	executeCtx.Info("Handler finished successfully")
+	cleanup()
+
+	if err = completeLifecycle(l.AutoScaling, m); err != nil {
+		ctx.WithError(err).Error("Failed to complete lifecycle action")
+		return
+	}
+
+	ctx.Info("Lifecycle action completed successfully")
+}
+
+func sendHeartbeat(svc *autoscaling.AutoScaling, m autoscalingMessage) error {
+	_, err := svc.RecordLifecycleActionHeartbeat(&autoscaling.RecordLifecycleActionHeartbeatInput{
+		AutoScalingGroupName: aws.String(m.GroupName),
+		LifecycleHookName:    aws.String(m.HookName),
+		InstanceId:           aws.String(m.InstanceID),
+		LifecycleActionToken: aws.String(m.ActionToken),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func completeLifecycle(svc *autoscaling.AutoScaling, m autoscalingMessage) error {
+	_, err := svc.CompleteLifecycleAction(&autoscaling.CompleteLifecycleActionInput{
+		AutoScalingGroupName:  aws.String(m.GroupName),
+		LifecycleHookName:     aws.String(m.HookName),
+		InstanceId:            aws.String(m.InstanceID),
+		LifecycleActionToken:  aws.String(m.ActionToken),
+		LifecycleActionResult: aws.String("CONTINUE"),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"encoding/json"
@@ -38,7 +37,6 @@ type LifecycleMonitor struct {
 	InstanceID  string
 	Queue       *Queue
 	AutoScaling *autoscaling.AutoScaling
-	Handler     *os.File
 }
 
 func (l *LifecycleMonitor) create() error {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -74,10 +74,6 @@ func (l *LifecycleMonitor) Run(ctx context.Context, termCh chan TerminationNotic
 		return err
 	}
 
-	defer func() {
-
-	}()
-
 	ch := make(chan *sqs.Message)
 
 	go func() {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -111,12 +111,10 @@ func (l *LifecycleMonitor) Run(ctx context.Context, termCh chan TerminationNotic
 		}()
 
 		doneCh := make(chan struct{})
-		errCh := make(chan error)
 
 		termCh <- TerminationNotice{
-			Done:  doneCh,
-			Error: errCh,
-			Args:  []string{msg.Transition, msg.InstanceID},
+			Done: doneCh,
+			Args: []string{msg.Transition, msg.InstanceID},
 		}
 
 		select {
@@ -134,9 +132,6 @@ func (l *LifecycleMonitor) Run(ctx context.Context, termCh chan TerminationNotic
 			}
 
 			return nil
-
-		case <-errCh:
-			hbt.Stop()
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		}
 
 		if instanceID == "" {
-			log.Infof("Looking up instance id from metadata service")
+			log.Debug("Looking up instance id from metadata service")
 			id, err := getInstanceID()
 			if err != nil {
 				log.Fatalf("Failed to lookup instance id: %v", err)

--- a/main.go
+++ b/main.go
@@ -137,10 +137,8 @@ func main() {
 		daemon := Daemon{
 			InstanceID: instanceID,
 			Handler:    handler,
-
 			SpotMonitor: &SpotMonitor{
 				InstanceID: instanceID,
-				Handler:    handler,
 			},
 		}
 
@@ -149,7 +147,6 @@ func main() {
 				InstanceID:  instanceID,
 				Queue:       NewQueue(sess, generateQueueName(instanceID), snsTopic),
 				AutoScaling: autoscaling.New(sess),
-				Handler:     handler,
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -135,6 +135,9 @@ func main() {
 		}()
 
 		daemon := Daemon{
+			InstanceID: instanceID,
+			Handler:    handler,
+
 			SpotMonitor: &SpotMonitor{
 				InstanceID: instanceID,
 				Handler:    handler,

--- a/spot.go
+++ b/spot.go
@@ -22,7 +22,7 @@ type SpotMonitor struct {
 	Handler    *os.File
 }
 
-func (s *SpotMonitor) Run(ctx context.Context) error {
+func (s *SpotMonitor) Run(ctx context.Context, termCh chan TerminationNotice) error {
 	log.Debugf("Polling metadata service for spot termination notices")
 
 	for {

--- a/spot.go
+++ b/spot.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"os/exec"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -15,52 +17,75 @@ const (
 	terminationTimeFormat      = "2006-01-02T15:04:05Z"
 )
 
-func pollSpotTermination(ctx context.Context) chan time.Time {
-	ch := make(chan time.Time)
+type SpotMonitor struct {
+	InstanceID string
+	Handler    *os.File
+}
 
+func (s *SpotMonitor) Run(ctx context.Context) error {
 	log.Debugf("Polling metadata service for spot termination notices")
 
-	go func() {
-		// Close channel before returning since this (goroutine) is the sending side.
-		defer close(ch)
-		retry := time.NewTicker(time.Second * 5).C
-	Loop:
-		for {
-			select {
-			case <-ctx.Done():
-				break Loop
-			case <-retry:
-				res, err := http.Get(metadataURLTerminationTime)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.NewTicker(time.Second * 5).C:
+			has, err := hasSpotTerminationNotice()
+			if err != nil {
+				log.WithError(err).Info("Failed to query spot termination notice")
+				continue
+			}
+			if has {
+				log.Info("Executing handler")
+				timer := time.Now()
+
+				cmd := exec.Command(s.Handler.Name(), terminationTransition, s.InstanceID)
+				cmd.Env = os.Environ()
+				cmd.Stdout = os.Stderr
+				cmd.Stderr = os.Stderr
+				err := cmd.Run()
+
+				executeCtx := log.WithFields(log.Fields{
+					"duration": time.Now().Sub(timer),
+				})
+
 				if err != nil {
-					log.WithError(err).Info("Failed to query metadata service")
-					continue
+					executeCtx.WithError(err).Error("Handler script failed")
+					return err
 				}
 
-				// We read the body immediately so that we can close the body in one place
-				// and still use 'continue' if any of our conditions are false.
-				body, err := ioutil.ReadAll(res.Body)
-				res.Body.Close()
-				if err != nil {
-					log.WithError(err).Info("Failed to read response from metadata service")
-					continue
-				}
-
-				// will return 200 OK with termination notice
-				if res.StatusCode != http.StatusOK {
-					continue
-				}
-
-				// if 200 OK, expect a body like 2015-01-05T18:02:00Z
-				t, err := time.Parse(terminationTimeFormat, string(body))
-				if err != nil {
-					log.WithError(err).Info("Failed to parse time in termination notice")
-					continue
-				}
-
-				ch <- t
+				executeCtx.Info("Handler finished successfully")
 			}
 		}
-	}()
+	}
+}
 
-	return ch
+func hasSpotTerminationNotice() (bool, error) {
+	res, err := http.Get(metadataURLTerminationTime)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	// will return 200 OK with termination notice
+	if res.StatusCode != http.StatusOK {
+		return false, nil
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return false, err
+	}
+
+	// if 200 OK, expect a body like 2015-01-05T18:02:00Z
+	t, err := time.Parse(terminationTimeFormat, string(body))
+	if err != nil {
+		return false, err
+	}
+
+	log.WithFields(log.Fields{
+		"time": t,
+	}).Info("Received spot instance termination notice")
+
+	return true, nil
 }

--- a/spot.go
+++ b/spot.go
@@ -35,17 +35,14 @@ func (s *SpotMonitor) Run(ctx context.Context, termCh chan TerminationNotice) er
 			if has {
 				log.Info("Received spot termination notice")
 				doneCh := make(chan struct{})
-				errCh := make(chan error)
 
 				termCh <- TerminationNotice{
-					Done:  doneCh,
-					Error: errCh,
-					Args:  []string{terminationTransition, s.InstanceID},
+					Done: doneCh,
+					Args: []string{terminationTransition, s.InstanceID},
 				}
 
 				select {
 				case <-doneCh:
-				case <-errCh:
 				}
 			}
 		}

--- a/spot.go
+++ b/spot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -18,7 +17,6 @@ const (
 
 type SpotMonitor struct {
 	InstanceID string
-	Handler    *os.File
 }
 
 func (s *SpotMonitor) Run(ctx context.Context, termCh chan TerminationNotice) error {


### PR DESCRIPTION
Thinking about #42 prompted me to try more elegantly splitting the spot and lifecycle monitoring into dedicated objects and leaving the `Daemon` entirely focused on process management.

This cleans up the SQS queue as soon as the lifecycle handler script has completed successfully, which seems about as quick as is possible.

Thoughts @itsdalmo? 