### PR TITLE
Use context for interupting handler script

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,7 +139,6 @@ func main() {
 			InstanceID:  instanceID,
 			AutoScaling: autoscaling.New(sess),
 			Handler:     handler,
-			Signals:     sigs,
 			Queue:       NewQueue(sess, generateQueueName(instanceID), snsTopic),
 		}
 


### PR DESCRIPTION
As mentioned in https://github.com/buildkite/lifecycled/issues/12#issuecomment-419011157:

> Just noticed this problem also https://github.com/buildkite/lifecycled/blob/master/daemon.go#L179. Since we have two go-routines reading from the same channel, executeHandler might actually read a signal in place of the go-routine in main.go, which means that the context is never cancelled.

This uses the context and `exec.CommandContext` instead of passing the signal channel. 