### PR TITLE
Ditch the aws module which uses cloudformation

### DIFF
--- a/terraform/example.tf
+++ b/terraform/example.tf
@@ -2,10 +2,6 @@ terraform {
   required_version = "0.11.8"
 }
 
-provider "aws" {
-  version = "1.34.0"
-}
-
 # Use the default VPC and subnets
 data "aws_vpc" "main" {
   default = true

--- a/terraform/example.tf
+++ b/terraform/example.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = "0.11.8"
 }
 
+provider "aws" {
+  version = "1.34.0"
+}
+
 # Use the default VPC and subnets
 data "aws_vpc" "main" {
   default = true
@@ -39,7 +43,7 @@ data "aws_ami" "linux2" {
 
 variable "instance_key" {
   description = "Name of EC2 Keypair"
-  default = "lifecycled-example"
+  default     = "lifecycled-example"
 }
 
 module "example" {

--- a/terraform/modules/example/cloud-config.yml
+++ b/terraform/modules/example/cloud-config.yml
@@ -1,7 +1,4 @@
 #cloud-config
-package_update: true
-packages:
-  - aws-cfn-bootstrap
 write_files:
   - path: "/etc/systemd/system/lifecycled.service"
     permissions: "0644"
@@ -23,23 +20,6 @@ write_files:
 
       [Install]
       WantedBy=multi-user.target
-  - path: "/usr/local/scripts/cloudformation-signal.sh"
-    permissions: "0744"
-    owner: "root"
-    content: |
-      #! /usr/bin/bash
-
-      set -euo pipefail
-
-      function await_unit() {
-        echo -n "Waiting for $1..."
-        while ! systemctl is-active $1 > /dev/null; do
-            sleep 1
-        done
-        echo "Done!"
-      }
-
-      await_unit lifecycled.service
   - path: "/usr/local/scripts/lifecycle-handler.sh"
     permissions: "0744"
     owner: "root"
@@ -52,13 +32,10 @@ write_files:
       sleep 120
       echo "goodbye from the handler"
 runcmd:
-  - | 
+  - |
     aws s3 cp s3://${artifact_bucket}/${artifact_key} /usr/local/bin/lifecycled
     chmod +x /usr/local/bin/lifecycled
     chown root:root /usr/local/bin/lifecycled
     echo "lifecycled ${artifact_etag} installed"
   - |
     systemctl enable lifecycled.service --now
-  - |
-    /usr/local/scripts/cloudformation-signal.sh
-    /opt/aws/bin/cfn-signal -e $? --stack ${stack_name} --resource AutoScalingGroup --region ${region}

--- a/terraform/modules/example/main.tf
+++ b/terraform/modules/example/main.tf
@@ -59,7 +59,7 @@ resource "aws_autoscaling_group" "main" {
   min_size         = "0"
   desired_capacity = "${var.instance_count}"
   max_size         = "1"
-  tags              = "${var.tags}"
+  tags              = ["${var.tags}"]
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
This ditches the `telia-oss/asg/aws` module in favor of directly using a launch configuration and an ASG. For testing, this is much faster to iterate with.