### PR TITLE
Enable spot listener by default and add --no-spot flag to disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Handler scripts are used for things like shutting down services that need some t
 set -euo pipefail
 function await_shutdown() {
   echo -n "Waiting for $1..."
-  while ! systemctl is-active $1 > /dev/null; do
+  while systemctl is-active $1 > /dev/null; do
     sleep 1
   done
   echo "Done!"
 }
 systemctl stop myservice.service
-await_unit myservice.service
+await_shutdown myservice.service
 ```
 
 The handler script is passed the event that was received and the instance id, e.g `autoscaling:EC2_INSTANCE_TERMINATING i-001405f0fc67e3b12` for lifecycle events, or `ec2:SPOT_INSTANCE_TERMINATION i-001405f0fc67e3b12 2015-01-05T18:02:00Z` in the case of a spot termination.

--- a/autoscaling.go
+++ b/autoscaling.go
@@ -182,5 +182,5 @@ func (n *autoscalingTerminationNotice) Handle(ctx context.Context, handler Handl
 		}
 	}()
 
-	return handler.Execute(ctx, n.message.InstanceID, n.message.Transition)
+	return handler.Execute(ctx, n.message.Transition, n.message.InstanceID)
 }

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -30,14 +30,14 @@ func main() {
 	app.DefaultEnvars()
 
 	var (
-		instanceID       string
-		snsTopic         string
-		spotListener     bool
-		handler          *os.File
-		jsonLogging      bool
-		debugLogging     bool
-		cloudwatchGroup  string
-		cloudwatchStream string
+		instanceID          string
+		snsTopic            string
+		disableSpotListener bool
+		handler             *os.File
+		jsonLogging         bool
+		debugLogging        bool
+		cloudwatchGroup     string
+		cloudwatchStream    string
 	)
 
 	app.Flag("instance-id", "The instance id to listen for events for").
@@ -46,8 +46,8 @@ func main() {
 	app.Flag("sns-topic", "The SNS topic that receives events").
 		StringVar(&snsTopic)
 
-	app.Flag("spot", "Listen for spot termination notices").
-		BoolVar(&spotListener)
+	app.Flag("no-spot", "Disable the spot termination listener").
+		BoolVar(&disableSpotListener)
 
 	app.Flag("handler", "The script to invoke to handle events").
 		FileVar(&handler)
@@ -135,7 +135,7 @@ func main() {
 		daemon := lifecycled.New(&lifecycled.Config{
 			InstanceID:           instanceID,
 			SNSTopic:             snsTopic,
-			SpotListener:         spotListener,
+			SpotListener:         !disableSpotListener,
 			SpotListenerInterval: 5 * time.Second,
 		}, sess, logger)
 

--- a/daemon.go
+++ b/daemon.go
@@ -145,7 +145,7 @@ type TerminationNotice interface {
 
 // Handler ...
 type Handler interface {
-	Execute(ctx context.Context, instanceID, transition string) error
+	Execute(ctx context.Context, args ...string) error
 }
 
 // NewFileHandler ...
@@ -159,8 +159,8 @@ type FileHandler struct {
 }
 
 // Execute the file handler.
-func (h *FileHandler) Execute(ctx context.Context, instanceID, transition string) error {
-	cmd := exec.CommandContext(ctx, h.file.Name(), instanceID, transition)
+func (h *FileHandler) Execute(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, h.file.Name(), args...)
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr

--- a/spot.go
+++ b/spot.go
@@ -88,5 +88,5 @@ func (n *spotTerminationNotice) Type() string {
 }
 
 func (n *spotTerminationNotice) Handle(ctx context.Context, handler Handler, log *logrus.Entry) error {
-	return handler.Execute(ctx, n.instanceID, n.transition)
+	return handler.Execute(ctx, n.transition, n.instanceID, n.terminationTime.Format(time.RFC3339))
 }

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -91,7 +91,7 @@ func listInstances(sess *session.Session) ([]string, error) {
 	// Only grab instances that are running or just started
 	params := &ec2.DescribeInstancesInput{
 		Filters: []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name:   aws.String(`instance-state-name`),
 				Values: aws.StringSlice([]string{"running", "pending"}),
 			},


### PR DESCRIPTION
@lox - I've added the flag you suggested in #53, and took the opportunity to:

- Align the arguments passed to the handler with what is documented in the README (I should have seen this earlier).
- Checked in a "linting fix" which `make test` does automatically everytime I run it.
- Fixed the example handler script in the documentation. On this, I think `systemctl stop <service>` is a blocking, so I'm not sure we need the `await_shutdown` script?