### PR TITLE
Add encryption to SQS queue

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -74,6 +74,7 @@ func (q *Queue) Create() error {
 		Attributes: map[string]*string{
 			"Policy":                        aws.String(fmt.Sprintf(queuePolicy, q.topicArn)),
 			"ReceiveMessageWaitTimeSeconds": aws.String(strconv.Itoa(longPollingWaitTimeSeconds)),
+			"KmsMasterKeyId":                aws.String("alias/aws/sqs"),
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
NOTE: I haven't tested this and I don't use lifecycled myself! I was browsing the issues for buildkite/elastic-ci-stack-for-aws and saw this issue, and I've recently done the same thing for some SQS queues at $work.

Fixes buildkite/elastic-ci-stack-for-aws#458