### PR TITLE
Move SpotListener newTicker out of the infinite loop 

### DIFF
--- a/spot.go
+++ b/spot.go
@@ -39,11 +39,14 @@ func (l *SpotListener) Start(ctx context.Context, notices chan<- TerminationNoti
 	if !l.metadata.Available() {
 		return errors.New("ec2 metadata is not available")
 	}
+	
+	tockChan := time.NewTicker(l.interval).C
+	
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-time.NewTicker(l.interval).C:
+		case <-tockChan:
 			log.Debug("Polling ec2 metadata for spot termination notices")
 
 			out, err := l.metadata.GetMetadata("spot/termination-time")


### PR DESCRIPTION
Regarding #71 

I'm not 100% certain this isn't a red herring. I have to wait for some amount of time see if the leak goes away on my side. pprof didn't show anything hugely out of the ordinary but I could have missed something.

This looks like it was creating a NewTicker on each iteration of the for loop without cleaning it up resulting in a slow increase of CPU churn over time. Moving the NewTicker outside of the loop and setting the case to strike only when the single instance of `tockChan` signals should help alleviate growth.