### PR TITLE
Defer call to stop ticker when spot listener returns

### DIFF
--- a/spot.go
+++ b/spot.go
@@ -39,14 +39,15 @@ func (l *SpotListener) Start(ctx context.Context, notices chan<- TerminationNoti
 	if !l.metadata.Available() {
 		return errors.New("ec2 metadata is not available")
 	}
-	
-	tockChan := time.NewTicker(l.interval).C
-	
+
+	ticker := time.NewTicker(l.interval)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
-		case <-tockChan:
+		case <-ticker.C:
 			log.Debug("Polling ec2 metadata for spot termination notices")
 
 			out, err := l.metadata.GetMetadata("spot/termination-time")


### PR DESCRIPTION
Tiny fix for correctness on top of #72, related to #71.

Renamed `tockChan` to `ticker` since its no longer just the channel, and also because it is the naming we used for the ticker here: https://github.com/buildkite/lifecycled/blob/master/autoscaling.go#L165.