### PR TITLE
Add ioutil.Discard to logger to prevent leaks

### DIFF
--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -106,6 +107,7 @@ func main() {
 			}).Info("Writing logs to CloudWatch")
 
 			logger.AddHook(hook)
+			logger.Out = ioutil.Discard
 			if !jsonLogging {
 				logger.SetFormatter(&logrus.TextFormatter{
 					DisableColors:    true,


### PR DESCRIPTION
Related to #71. The documentation in https://github.com/kdar/logrus-cloudwatchlogs alludes (albeit vaguely) to the fact that ioutil.Discard is required to release memory and may actually be related to this issue in logrus upstream, https://github.com/Sirupsen/logrus/issues/328.

This likely has the side-effect of disabling logging to stdout so I'm not sure this is desirable.