### PR TITLE
Restart lifecycled on SIGPIPE from systemd

### DIFF
--- a/init/systemd/lifecycled.unit
+++ b/init/systemd/lifecycled.unit
@@ -6,6 +6,7 @@ After=network-online.target
 [Service]
 Type=simple
 Restart=on-failure
+RestartForceExitStatus=SIGPIPE
 RestartSec=30s
 TimeoutStopSec=5m
 EnvironmentFile=/etc/lifecycled


### PR DESCRIPTION
Similar to https://github.com/influxdata/influxdb/issues/7040, on Amazon Linux lifecycled doesn't restart gracefully on `SIGPIPE`. This fixes the issue. 