### PR TITLE
Fixes listener variable re-use

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -93,7 +93,7 @@ func (d *Daemon) Start(ctx context.Context) (notice TerminationNotice, err error
 
 		l := log.WithField("listener", listener.Type())
 
-		go func() {
+		go func(listener Listener) {
 			defer wg.Done()
 
 			if err := listener.Start(listenerCtx, notices, l); err != nil {
@@ -102,7 +102,7 @@ func (d *Daemon) Start(ctx context.Context) (notice TerminationNotice, err error
 			} else {
 				l.Info("Stopped listener")
 			}
-		}()
+		}(listener)
 		l.Info("Starting listener")
 	}
 


### PR DESCRIPTION
Fix for #84. Passes listener to the closure in order to ensure listener is unique for each goroutine.