### PR TITLE
Support configuring intervals for spot instance termination and autoscaling heartbeats

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -52,17 +52,18 @@ func NewDaemon(
 			sqsClient,
 			snsClient,
 		)
-		daemon.AddListener(NewAutoscalingListener(config.InstanceID, queue, asgClient))
+		daemon.AddListener(NewAutoscalingListener(config.InstanceID, queue, asgClient, config.AutoscalingHeartbeatInterval))
 	}
 	return daemon
 }
 
 // Config for the Lifecycled Daemon.
 type Config struct {
-	InstanceID           string
-	SNSTopic             string
-	SpotListener         bool
-	SpotListenerInterval time.Duration
+	InstanceID                   string
+	SNSTopic                     string
+	SpotListener                 bool
+	SpotListenerInterval         time.Duration
+	AutoscalingHeartbeatInterval time.Duration
 }
 
 // Daemon is what orchestrates the listening and execution of the handler on a termination notice.


### PR DESCRIPTION
We've found the default 10s heartbeat interval to be a little too fast for our particular use-case, so we'd love to be able to to configure it via a flag/envvar. While I was at it, I went ahead and added support for configuring the spot listener interval just for consistency.

Let me know what you think! I'm totally happy to change anything.