### PR TITLE
Add support for configuring additional handler arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,29 @@ systemctl stop myservice.service
 await_shutdown myservice.service
 ```
 
+### Handler Arguments
 The handler script is passed the event that was received and the instance id, e.g `autoscaling:EC2_INSTANCE_TERMINATING i-001405f0fc67e3b12` for lifecycle events, or `ec2:SPOT_INSTANCE_TERMINATION i-001405f0fc67e3b12 2015-01-05T18:02:00Z` in the case of a spot termination.
+
+Additional arguments can be provided to lifecycled using the environment variable `LIFECYCLED_HANDLER_ARGS` or the flag `--handler-args` flag one or more times. When using additional arguments, the default arguments will be appended to the end of the argument list.
+
+E.g. The following instance of lifecycled will pass the handler script arguments `argument1 argument2 autoscaling:EC2_INSTANCE_TERMINATING i-001405f0fc67e3b12`
+
+```bash
+lifecycled --handler-args "argument1" --handler-args "argument2"
+```
+
+### Handlers on Windows
+Due to the nature of executables in Windows, a Powershell script can’t be passed as a handler directly without additional configuration to your Windows registry. Instead you can use Powershell as the executable handler and a separate Powershell script as an additional argument which will be executed. The Powershell script executed will receive any additional arguments, such as the event and instance id.
+
+```powershell
+$env:LIFECYCLED_HANDLER="$env:SYSTEMROOT\System32\WindowsPowerShell\v1.0\powershell.exe"
+$env:LIFECYCLED_HANDLER_ARGS="$env:ProgramData\lifecycled\handler.ps1"
+$env:LIFECYCLED_SNS_TOPIC="arn:aws:sns:us-east-1:11111111:my-lifecycle-topic"
+$env:AWS_REGION="us-east-1"
+
+
+.\lifecycled-windows-amd64.exe
+```
 
 ## Licence
 

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -33,6 +33,7 @@ func main() {
 		snsTopic                     string
 		disableSpotListener          bool
 		handler                      *os.File
+		handlerArgs                  []string
 		jsonLogging                  bool
 		debugLogging                 bool
 		cloudwatchGroup              string
@@ -53,6 +54,9 @@ func main() {
 	app.Flag("handler", "The script to invoke to handle events").
 		Required().
 		FileVar(&handler)
+
+	app.Flag("handler-args", "Additional arguments to pass to the script invoked by the handler").
+		StringsVar(&handlerArgs)
 
 	app.Flag("json", "Enable JSON logging").
 		BoolVar(&jsonLogging)
@@ -156,7 +160,7 @@ func main() {
 			}
 		}()
 
-		handler := lifecycled.NewFileHandler(handler)
+		handler := lifecycled.NewFileHandler(handler, handlerArgs)
 		daemon := lifecycled.New(&lifecycled.Config{
 			InstanceID:                   instanceID,
 			SNSTopic:                     snsTopic,

--- a/daemon.go
+++ b/daemon.go
@@ -150,18 +150,20 @@ type Handler interface {
 }
 
 // NewFileHandler ...
-func NewFileHandler(file *os.File) *FileHandler {
-	return &FileHandler{file: file}
+func NewFileHandler(file *os.File, args []string) *FileHandler {
+	return &FileHandler{file: file, args: args}
 }
 
 // FileHandler ...
 type FileHandler struct {
 	file *os.File
+	args []string
 }
 
 // Execute the file handler.
 func (h *FileHandler) Execute(ctx context.Context, args ...string) error {
-	cmd := exec.CommandContext(ctx, h.file.Name(), args...)
+	cmdArguments := append(h.args, args...)
+	cmd := exec.CommandContext(ctx, h.file.Name(), cmdArguments...)
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Currently the handler executed by lifecycled is given the lifecycle event name, instance-id and optionally a time (EC2 Spot Instance).

Adding support for additional arguments will assist with providing more information for the handler and also the execution of scripts in a Windows environment, which can't execute a Powershell script directly as it is not an executable. Instead by making the handler Powershell, you can provide a script location as an additional argument which will be invoked. 