### PR TITLE
Upgrade Go version

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: go test ./...
     plugins:
       - golang#v2.0.0:
-          version: 1.16.3
+          version: 1.17
           import: github.com/buildkite/lifecycled
           environment:
             - GO111MODULE=on


### PR DESCRIPTION
The latest version is 1.23.6 so we are still way behind, but I want it to do it gradually and make sure I'm not breaking anything, and particularly, `x/sys` needs 1.17 or higher