### PR TITLE
PS-854-sqs remove deletequeue when the listener exits

### DIFF
--- a/autoscaling.go
+++ b/autoscaling.go
@@ -65,12 +65,6 @@ func (l *AutoscalingListener) Start(ctx context.Context, notices chan<- Terminat
 	if err := l.queue.Create(); err != nil {
 		return err
 	}
-	defer func() {
-		log.WithField("queue", l.queue.name).Debug("Deleting sqs queue")
-		if err := l.queue.Delete(); err != nil {
-			log.WithError(err).Error("Failed to delete queue")
-		}
-	}()
 
 	log.WithField("topic", l.queue.topicArn).Debug("Subscribing queue to sns topic")
 	if err := l.queue.Subscribe(); err != nil {

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -124,7 +124,6 @@ func TestDaemon(t *testing.T) {
 				sq.EXPECT().GetQueueAttributes(gomock.Any()).Times(1).Return(&sqs.GetQueueAttributesOutput{
 					Attributes: map[string]*string{"QueueArn": aws.String("arn")},
 				}, nil)
-				sq.EXPECT().DeleteQueue(gomock.Any()).Times(1).Return(nil, nil)
 
 				if tc.subscribeError == nil {
 					sq.EXPECT().ReceiveMessageWithContext(gomock.Any(), gomock.Any()).MinTimes(1).Return(&sqs.ReceiveMessageOutput{


### PR DESCRIPTION
### issue
When lifecycled is stopped it deletes its SQS queue. Whilst this makes sense, it makes it impossible to safely restart the service. If I run systemctl restart lifecycled it refuses to start for ~60 seconds.


### Solution
No longer call DeleteQueue when the listener exits, so the queue (and its name) survive a stop/start or systemctl restart of the service.
Using CreateQueue will return an existing queue if one already exists
The queue name remains lifecycled-<instance-id>, so a single instance will never accumulate multiple queues across restarts.
I feel this is a safe change? Thoughts @zhming0 @DrJosh9000 @moskyb 