### PR TITLE
Bump Go to 1.26.4 to fix stdlib issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: go test ./...
     plugins:
       - golang#v2.0.0:
-          version: 1.25.0
+          version: 1.26.4
           import: github.com/buildkite/lifecycled
           environment:
             - GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/lifecycled
 
-go 1.23.0
+go 1.26.4
 
 require (
 	github.com/alecthomas/kingpin v0.0.0-20180312062423-a39589180ebd


### PR DESCRIPTION
Addresses https://pkg.go.dev/vuln/GO-2026-4337