### PR TITLE
Add support for AWS SSO to `lifecycled-queue-cleaner`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /handler.sh
 build/
 /lifecycled
+/tools/lifecycled-queue-cleaner/lifecycled-queue-cleaner
 .DS_Store
 
 # Terraform

--- a/README.md
+++ b/README.md
@@ -344,6 +344,19 @@ See the [terraform/](terraform/) directory for a complete Terraform example that
 - IAM roles and policies
 - CloudWatch log groups
 
+## Cleaning Up Orphaned Queues and Subscriptions
+
+For every instance it runs on, lifecycled creates an SQS queue and an SNS subscription named with a `lifecycled-` prefix. These are removed when an instance shuts down cleanly, but an ungraceful termination can leave them behind, and over time the orphans accumulate against your account's SQS and SNS limits.
+
+The [`lifecycled-queue-cleaner`](tools/lifecycled-queue-cleaner) tool removes them. It lists the running instances, then deletes the `lifecycled-` queues and subscriptions that no longer map to one. Because it is destructive, it logs the resolved region and account at startup and accepts an `-account` guard that aborts before any delete if the resolved account does not match.
+
+```bash
+cd tools/lifecycled-queue-cleaner
+go run . -account 123456789012
+```
+
+See the [tool's README](tools/lifecycled-queue-cleaner/README.md) for how it resolves credentials and region (including AWS SSO) and the IAM permissions it needs.
+
 ## Troubleshooting
 
 ### Checking Service Status

--- a/tools/lifecycled-queue-cleaner/README.md
+++ b/tools/lifecycled-queue-cleaner/README.md
@@ -38,10 +38,11 @@ aws sso login --profile my-profile
 AWS_PROFILE=my-profile go run .
 ```
 
-SSO sessions expire and are not refreshed mid-run, so a long cleanup can exit
-with an authentication error partway through. The tool re-lists queues and
-subscriptions on each run, so it is safe to run again after `aws sso login` and
-it picks up wherever the previous run left off.
+SSO sessions expire and are not refreshed mid-run. An expired session is caught
+at startup by the account check, and a long cleanup can also exit partway through
+once the session lapses; either way the tool prints a hint to re-authenticate.
+The tool re-lists queues and subscriptions on each run, so it is safe to run
+again after `aws sso login` and it picks up wherever the previous run left off.
 
 ## Required IAM permissions
 

--- a/tools/lifecycled-queue-cleaner/README.md
+++ b/tools/lifecycled-queue-cleaner/README.md
@@ -1,0 +1,35 @@
+# lifecycled-queue-cleaner
+
+An operator tool that deletes orphaned `lifecycled-` SQS queues and their SNS
+subscriptions left behind by terminated EC2 instances. It lists running
+instances, then removes the queues and subscriptions that no longer map to one.
+
+This is a destructive tool. Confirm the resolved region (logged at startup as
+`Using region ...`) before letting it run, and make sure the credentials in use
+point at the account you intend to clean.
+
+## Usage
+
+```bash
+go run . [-parallel N]
+```
+
+`-parallel` controls how many queue deletes run concurrently (default 20).
+
+## AWS credentials and region
+
+The tool builds its AWS session with shared configuration enabled, so it
+resolves credentials and region the same way the AWS CLI does. In precedence
+order, region comes from the `AWS_REGION` environment variable, then the active
+profile in `~/.aws/config`, and finally the EC2 instance metadata service when
+nothing else supplies one. If you run the tool off an EC2 instance with no
+region configured, set `AWS_REGION` (or a profile region) rather than relying on
+the metadata fallback.
+
+Because shared configuration is enabled, named profiles work via `AWS_PROFILE`,
+including AWS SSO profiles. To use SSO, log in first and select the profile:
+
+```bash
+aws sso login --profile my-profile
+AWS_PROFILE=my-profile go run .
+```

--- a/tools/lifecycled-queue-cleaner/README.md
+++ b/tools/lifecycled-queue-cleaner/README.md
@@ -6,15 +6,18 @@ instances, then removes the queues and subscriptions that no longer map to one.
 
 This is a destructive tool. It logs the resolved region and account at startup
 (`Using region ...` and `Using account ...`); confirm both point at what you
-intend to clean before letting it run.
+intend to clean before letting it run. Pass `-account <id>` to have it abort
+before deleting anything if the resolved account does not match.
 
 ## Usage
 
 ```bash
-go run . [-parallel N]
+go run . [-parallel N] [-account AWS_ACCOUNT_ID]
 ```
 
 `-parallel` controls how many queue deletes run concurrently (default 20).
+`-account` aborts before any delete if the resolved account ID does not match,
+guarding against running against the wrong account.
 
 ## AWS credentials and region
 

--- a/tools/lifecycled-queue-cleaner/README.md
+++ b/tools/lifecycled-queue-cleaner/README.md
@@ -34,3 +34,20 @@ including AWS SSO profiles. To use SSO, log in first and select the profile:
 aws sso login --profile my-profile
 AWS_PROFILE=my-profile go run .
 ```
+
+SSO sessions expire and are not refreshed mid-run, so a long cleanup can exit
+with an authentication error partway through. The tool re-lists queues and
+subscriptions on each run, so it is safe to run again after `aws sso login` and
+it picks up wherever the previous run left off.
+
+## Required IAM permissions
+
+The credentials need:
+
+- `ec2:DescribeInstances`
+- `sqs:ListQueues` and `sqs:DeleteQueue`
+- `sns:ListSubscriptions`, `sns:GetTopicAttributes`, and `sns:Unsubscribe`
+
+`sts:GetCallerIdentity`, used for the startup account check, requires no
+permission. Missing any of the above surfaces as a fatal error partway through a
+run, so confirm the policy before a large cleanup.

--- a/tools/lifecycled-queue-cleaner/README.md
+++ b/tools/lifecycled-queue-cleaner/README.md
@@ -4,9 +4,9 @@ An operator tool that deletes orphaned `lifecycled-` SQS queues and their SNS
 subscriptions left behind by terminated EC2 instances. It lists running
 instances, then removes the queues and subscriptions that no longer map to one.
 
-This is a destructive tool. Confirm the resolved region (logged at startup as
-`Using region ...`) before letting it run, and make sure the credentials in use
-point at the account you intend to clean.
+This is a destructive tool. It logs the resolved region and account at startup
+(`Using region ...` and `Using account ...`); confirm both point at what you
+intend to clean before letting it run.
 
 ## Usage
 
@@ -20,11 +20,12 @@ go run . [-parallel N]
 
 The tool builds its AWS session with shared configuration enabled, so it
 resolves credentials and region the same way the AWS CLI does. In precedence
-order, region comes from the `AWS_REGION` environment variable, then the active
-profile in `~/.aws/config`, and finally the EC2 instance metadata service when
-nothing else supplies one. If you run the tool off an EC2 instance with no
-region configured, set `AWS_REGION` (or a profile region) rather than relying on
-the metadata fallback.
+order, region comes from `AWS_REGION`, then `AWS_DEFAULT_REGION`, then the region
+of the active profile in `~/.aws/config` (selected by `AWS_PROFILE`, or the
+`default` profile), and finally the EC2 instance metadata service when nothing
+else supplies one. If you run the tool off an EC2 instance with no region
+configured, set `AWS_REGION` or `AWS_DEFAULT_REGION` (or a profile region) rather
+than relying on the metadata fallback.
 
 Because shared configuration is enabled, named profiles work via `AWS_PROFILE`,
 including AWS SSO profiles. To use SSO, log in first and select the profile:

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -42,7 +43,10 @@ func main() {
 
 	// Confirm the target account before any destructive calls. GetCallerIdentity
 	// needs no IAM permission, so a failure means the credentials are unusable.
-	ident, err := sts.New(sess).GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	// Bound the check so a slow or hung STS fails fast instead of stalling startup.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ident, err := sts.New(sess).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		log.Fatalf("Failed to resolve caller identity: %s", err)
 	}
@@ -89,6 +93,9 @@ func resolveRegion(sess *session.Session, lookupRegion func() (string, error)) e
 	region, err := lookupRegion()
 	if err != nil {
 		return fmt.Errorf("look up region from EC2 metadata (set AWS_REGION, AWS_DEFAULT_REGION, or a profile region instead): %w", err)
+	}
+	if region == "" {
+		return fmt.Errorf("EC2 metadata returned an empty region (set AWS_REGION, AWS_DEFAULT_REGION, or a profile region instead)")
 	}
 	sess.Config.Region = aws.String(region)
 	return nil

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -23,6 +23,7 @@ import (
 
 func main() {
 	parallel := flag.Int("parallel", 20, "The number of parallel deletes to run")
+	account := flag.String("account", "", "If set, abort unless the resolved AWS account ID matches")
 	flag.Parse()
 
 	// SharedConfigEnable loads ~/.aws/config so region, named profiles, and SSO resolve.
@@ -49,6 +50,9 @@ func main() {
 	ident, err := sts.New(sess).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		log.Fatalf("Failed to resolve caller identity: %s", err)
+	}
+	if *account != "" && *account != aws.StringValue(ident.Account) {
+		log.Fatalf("Resolved account %s does not match the expected account %s", aws.StringValue(ident.Account), *account)
 	}
 	log.Printf("Using account %s as %s", aws.StringValue(ident.Account), aws.StringValue(ident.Arn))
 

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -119,16 +119,17 @@ func fatalAWS(err error) {
 // resolveRegion fills in the session region from EC2 metadata when neither the
 // environment nor shared config supplied one. lookupRegion is injectable for tests.
 func resolveRegion(sess *session.Session, lookupRegion func() (string, error)) error {
+	const hint = "set AWS_REGION, AWS_DEFAULT_REGION, or a profile region instead"
 	if aws.StringValue(sess.Config.Region) != "" {
 		return nil
 	}
 	log.Println("No region in environment or shared config, looking up from EC2 metadata")
 	region, err := lookupRegion()
 	if err != nil {
-		return fmt.Errorf("look up region from EC2 metadata (set AWS_REGION, AWS_DEFAULT_REGION, or a profile region instead): %w", err)
+		return fmt.Errorf("look up region from EC2 metadata (%s): %w", hint, err)
 	}
 	if region == "" {
-		return fmt.Errorf("EC2 metadata returned an empty region (set AWS_REGION, AWS_DEFAULT_REGION, or a profile region instead)")
+		return fmt.Errorf("EC2 metadata returned an empty region (%s)", hint)
 	}
 	sess.Config.Region = aws.String(region)
 	return nil

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 func main() {
@@ -38,6 +39,14 @@ func main() {
 	}
 
 	log.Printf("Using region %s", aws.StringValue(sess.Config.Region))
+
+	// Confirm the target account before any destructive calls. GetCallerIdentity
+	// needs no IAM permission, so a failure means the credentials are unusable.
+	ident, err := sts.New(sess).GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		log.Fatalf("Failed to resolve caller identity: %s", err)
+	}
+	log.Printf("Using account %s as %s", aws.StringValue(ident.Account), aws.StringValue(ident.Arn))
 
 	for {
 		count, err := deleteInactiveSubscriptions(sess)
@@ -79,7 +88,7 @@ func resolveRegion(sess *session.Session, lookupRegion func() (string, error)) e
 	log.Println("No region in environment or shared config, looking up from EC2 metadata")
 	region, err := lookupRegion()
 	if err != nil {
-		return fmt.Errorf("look up region from EC2 metadata (set AWS_REGION or a profile region instead): %w", err)
+		return fmt.Errorf("look up region from EC2 metadata (set AWS_REGION, AWS_DEFAULT_REGION, or a profile region instead): %w", err)
 	}
 	sess.Config.Region = aws.String(region)
 	return nil

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -23,21 +23,24 @@ func main() {
 	parallel := flag.Int("parallel", 20, "The number of parallel deletes to run")
 	flag.Parse()
 
-	region := os.Getenv("AWS_REGION")
-	if region == "" {
-		log.Println("Looking up region from metadata service")
-		sess, err := session.NewSession()
-		if err != nil {
-			log.Fatalf("Failed to create new aws session: %s", err)
-		}
-		region, err = ec2metadata.New(sess).Region()
-		if err != nil {
-			log.Fatalf("Failed to look up region: %s", err)
-		}
+	// SharedConfigEnable loads ~/.aws/config so region, named profiles, and SSO resolve.
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create aws session: %s", err)
 	}
 
+	if err := resolveRegion(sess, func() (string, error) {
+		return ec2metadata.New(sess).Region()
+	}); err != nil {
+		log.Fatalf("Failed to resolve region: %s", err)
+	}
+
+	log.Printf("Using region %s", aws.StringValue(sess.Config.Region))
+
 	for {
-		count, err := deleteInactiveSubscriptions(session.Must(session.NewSession(&aws.Config{Region: aws.String(region)})))
+		count, err := deleteInactiveSubscriptions(sess)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -51,7 +54,7 @@ func main() {
 	}
 
 	for {
-		count, err := deleteInactiveQueues(session.Must(session.NewSession(&aws.Config{Region: aws.String(region)})), *parallel)
+		count, err := deleteInactiveQueues(sess, *parallel)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -65,6 +68,21 @@ func main() {
 	}
 
 	log.Printf("Done! Sorry for the inconvenience!")
+}
+
+// resolveRegion fills in the session region from EC2 metadata when neither the
+// environment nor shared config supplied one. lookupRegion is injectable for tests.
+func resolveRegion(sess *session.Session, lookupRegion func() (string, error)) error {
+	if aws.StringValue(sess.Config.Region) != "" {
+		return nil
+	}
+	log.Println("No region in environment or shared config, looking up from EC2 metadata")
+	region, err := lookupRegion()
+	if err != nil {
+		return fmt.Errorf("look up region from EC2 metadata (set AWS_REGION or a profile region instead): %w", err)
+	}
+	sess.Config.Region = aws.String(region)
+	return nil
 }
 
 func deleteInactiveQueues(sess *session.Session, parallel int) (uint64, error) {

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -35,19 +35,19 @@ func main() {
 	}
 
 	if err := resolveRegion(sess, func() (string, error) {
-		return ec2metadata.New(sess).Region()
+		// Bound the metadata lookup so it fails fast off-EC2 instead of stalling startup.
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		return ec2metadata.New(sess).RegionWithContext(ctx)
 	}); err != nil {
 		log.Fatalf("Failed to resolve region: %s", err)
 	}
 
 	log.Printf("Using region %s", aws.StringValue(sess.Config.Region))
 
-	// Confirm the target account before any destructive calls. GetCallerIdentity
-	// needs no IAM permission, so a failure means the credentials are unusable.
-	// Bound the check so a slow or hung STS fails fast instead of stalling startup.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	ident, err := sts.New(sess).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
+	// Confirm the target account before any destructive calls. A failure means the
+	// credentials are unusable, since GetCallerIdentity needs no IAM permission.
+	ident, err := callerIdentity(sess)
 	if err != nil {
 		log.Fatalf("Failed to resolve caller identity: %s", err)
 	}
@@ -59,7 +59,7 @@ func main() {
 	for {
 		count, err := deleteInactiveSubscriptions(sess)
 		if err != nil {
-			log.Fatal(err)
+			fatalAWS(err)
 		}
 
 		if count == 0 {
@@ -73,7 +73,7 @@ func main() {
 	for {
 		count, err := deleteInactiveQueues(sess, *parallel)
 		if err != nil {
-			log.Fatal(err)
+			fatalAWS(err)
 		}
 
 		if count == 0 {
@@ -85,6 +85,35 @@ func main() {
 	}
 
 	log.Printf("Done! Sorry for the inconvenience!")
+}
+
+// callerIdentity resolves the account the credentials belong to, bounded so a
+// hung STS fails fast instead of stalling startup.
+func callerIdentity(sess *session.Session) (*sts.GetCallerIdentityOutput, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return sts.New(sess).GetCallerIdentityWithContext(ctx, &sts.GetCallerIdentityInput{})
+}
+
+// credentialExpiryCodes are the AWS error codes meaning the credentials
+// (temporary STS credentials or the cached SSO token) expired and need a refresh.
+var credentialExpiryCodes = map[string]struct{}{
+	`ExpiredToken`:            {},
+	`ExpiredTokenException`:   {},
+	`RequestExpired`:          {},
+	`SSOProviderInvalidToken`: {},
+}
+
+// fatalAWS ends the run, adding a re-auth hint when the failure is expired
+// credentials. Re-running is safe: each run re-lists from scratch and resumes
+// where the last left off.
+func fatalAWS(err error) {
+	if awsErr, ok := err.(awserr.Error); ok {
+		if _, expired := credentialExpiryCodes[awsErr.Code()]; expired {
+			log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", awsErr.Code(), err)
+		}
+	}
+	log.Fatal(err)
 }
 
 // resolveRegion fills in the session region from EC2 metadata when neither the
@@ -108,7 +137,7 @@ func resolveRegion(sess *session.Session, lookupRegion func() (string, error)) e
 func deleteInactiveQueues(sess *session.Session, parallel int) (uint64, error) {
 	queues, err := listInactiveQueues(sess)
 	if err != nil {
-		log.Fatal(err)
+		fatalAWS(err)
 	}
 
 	var wg sync.WaitGroup
@@ -205,7 +234,7 @@ var queueRegex = regexp.MustCompile(`^https://sqs\.(.+?)\.amazonaws.com/(.+?)/li
 func listInactiveQueues(sess *session.Session) ([]string, error) {
 	instances, err := listInstances(sess)
 	if err != nil {
-		log.Fatal(err)
+		fatalAWS(err)
 	}
 
 	log.Printf("Found %d running instances", len(instances))
@@ -218,7 +247,7 @@ func listInactiveQueues(sess *session.Session) ([]string, error) {
 
 	queues, err := listQueues(sess)
 	if err != nil {
-		log.Fatal(err)
+		fatalAWS(err)
 	}
 
 	log.Printf("Found %d queues total (aws returns max 1000)", len(queues))

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -44,6 +44,21 @@ func TestResolveRegion(t *testing.T) {
 		}
 	})
 
+	t.Run("fails when lookup returns an empty region", func(t *testing.T) {
+		sess := session.Must(session.NewSession())
+		sess.Config.Region = aws.String("")
+
+		err := resolveRegion(sess, func() (string, error) {
+			return "", nil
+		})
+		if err == nil {
+			t.Fatal("expected an error for an empty region, got nil")
+		}
+		if got := aws.StringValue(sess.Config.Region); got != "" {
+			t.Errorf("region = %q, want empty after empty lookup", got)
+		}
+	})
+
 	t.Run("wraps the lookup error", func(t *testing.T) {
 		sess := session.Must(session.NewSession())
 		sess.Config.Region = aws.String("")

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+func TestResolveRegion(t *testing.T) {
+	t.Run("keeps existing region without lookup", func(t *testing.T) {
+		sess := session.Must(session.NewSession())
+		sess.Config.Region = aws.String("us-west-2")
+
+		called := false
+		err := resolveRegion(sess, func() (string, error) {
+			called = true
+			return "ap-southeast-2", nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if called {
+			t.Error("metadata lookup ran despite region already being set")
+		}
+		if got := aws.StringValue(sess.Config.Region); got != "us-west-2" {
+			t.Errorf("region = %q, want us-west-2", got)
+		}
+	})
+
+	t.Run("falls back to metadata when region is empty", func(t *testing.T) {
+		sess := session.Must(session.NewSession())
+		sess.Config.Region = aws.String("")
+
+		err := resolveRegion(sess, func() (string, error) {
+			return "ap-southeast-2", nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if got := aws.StringValue(sess.Config.Region); got != "ap-southeast-2" {
+			t.Errorf("region = %q, want ap-southeast-2", got)
+		}
+	})
+
+	t.Run("wraps the lookup error", func(t *testing.T) {
+		sess := session.Must(session.NewSession())
+		sess.Config.Region = aws.String("")
+
+		want := errors.New("metadata unavailable")
+		err := resolveRegion(sess, func() (string, error) {
+			return "", want
+		})
+		if !errors.Is(err, want) {
+			t.Errorf("error = %v, want it to wrap %v", err, want)
+		}
+		if got := aws.StringValue(sess.Config.Region); got != "" {
+			t.Errorf("region = %q, want empty after failed lookup", got)
+		}
+	})
+}

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -9,69 +9,76 @@ import (
 )
 
 func TestResolveRegion(t *testing.T) {
-	t.Run("keeps existing region without lookup", func(t *testing.T) {
-		sess := session.Must(session.NewSession())
-		sess.Config.Region = aws.String("us-west-2")
+	sentinel := errors.New("metadata unavailable")
+	tests := []struct {
+		name       string
+		region     string
+		lookup     string
+		lookupErr  error
+		wantLookup bool
+		wantErr    bool
+		wantErrIs  error
+		wantRegion string
+	}{
+		{
+			name:       "keeps existing region without lookup",
+			region:     "us-west-2",
+			lookup:     "ap-southeast-2",
+			wantLookup: false,
+			wantRegion: "us-west-2",
+		},
+		{
+			name:       "falls back to metadata when region is empty",
+			region:     "",
+			lookup:     "ap-southeast-2",
+			wantLookup: true,
+			wantRegion: "ap-southeast-2",
+		},
+		{
+			name:       "fails when lookup returns an empty region",
+			region:     "",
+			lookup:     "",
+			wantLookup: true,
+			wantErr:    true,
+			wantRegion: "",
+		},
+		{
+			name:       "wraps the lookup error",
+			region:     "",
+			lookupErr:  sentinel,
+			wantLookup: true,
+			wantErr:    true,
+			wantErrIs:  sentinel,
+			wantRegion: "",
+		},
+	}
 
-		called := false
-		err := resolveRegion(sess, func() (string, error) {
-			called = true
-			return "ap-southeast-2", nil
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess := session.Must(session.NewSession())
+			sess.Config.Region = aws.String(tt.region)
+
+			called := false
+			err := resolveRegion(sess, func() (string, error) {
+				called = true
+				return tt.lookup, tt.lookupErr
+			})
+
+			if called != tt.wantLookup {
+				t.Errorf("lookup called = %v, want %v", called, tt.wantLookup)
+			}
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if tt.wantErrIs != nil && !errors.Is(err, tt.wantErrIs) {
+				t.Errorf("error = %v, want it to wrap %v", err, tt.wantErrIs)
+			}
+			if got := aws.StringValue(sess.Config.Region); got != tt.wantRegion {
+				t.Errorf("region = %q, want %q", got, tt.wantRegion)
+			}
 		})
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		if called {
-			t.Error("metadata lookup ran despite region already being set")
-		}
-		if got := aws.StringValue(sess.Config.Region); got != "us-west-2" {
-			t.Errorf("region = %q, want us-west-2", got)
-		}
-	})
-
-	t.Run("falls back to metadata when region is empty", func(t *testing.T) {
-		sess := session.Must(session.NewSession())
-		sess.Config.Region = aws.String("")
-
-		err := resolveRegion(sess, func() (string, error) {
-			return "ap-southeast-2", nil
-		})
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		if got := aws.StringValue(sess.Config.Region); got != "ap-southeast-2" {
-			t.Errorf("region = %q, want ap-southeast-2", got)
-		}
-	})
-
-	t.Run("fails when lookup returns an empty region", func(t *testing.T) {
-		sess := session.Must(session.NewSession())
-		sess.Config.Region = aws.String("")
-
-		err := resolveRegion(sess, func() (string, error) {
-			return "", nil
-		})
-		if err == nil {
-			t.Fatal("expected an error for an empty region, got nil")
-		}
-		if got := aws.StringValue(sess.Config.Region); got != "" {
-			t.Errorf("region = %q, want empty after empty lookup", got)
-		}
-	})
-
-	t.Run("wraps the lookup error", func(t *testing.T) {
-		sess := session.Must(session.NewSession())
-		sess.Config.Region = aws.String("")
-
-		want := errors.New("metadata unavailable")
-		err := resolveRegion(sess, func() (string, error) {
-			return "", want
-		})
-		if !errors.Is(err, want) {
-			t.Errorf("error = %v, want it to wrap %v", err, want)
-		}
-		if got := aws.StringValue(sess.Config.Region); got != "" {
-			t.Errorf("region = %q, want empty after failed lookup", got)
-		}
-	})
+	}
 }


### PR DESCRIPTION
Inspired by https://github.com/buildkite/lifecycled/pull/111, this adds support for AWS SSO to the `lifecycled-queue-cleaner` tool.