### PR TITLE
Generate mocks via go tool mockgen

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,23 +4,15 @@
 
 ### Required Tools
 
-- **Go**: Go 1.23.0 or later (required for module support and modern syntax)
+- **Go**: Go 1.26.4 or later (matches the `go` directive in `go.mod`; required for the `tool` directive and modern syntax)
 - **gox**: Cross-platform Go compilation tool (required for `make release`)
-- **mockgen**: Mock code generation tool (required for `make generate`)
+- **mockgen**: Provided as a `go.mod` `tool` dependency, so no separate install is needed (see [Code Generation](#code-generation))
 
 #### Installing gox
 
 ```bash
 go install github.com/mitchellh/gox@latest
 ```
-
-#### Installing mockgen
-
-```bash
-go install go.uber.org/mock/mockgen@latest
-```
-
-**Note**: This project uses `go.uber.org/mock` (the actively maintained fork) rather than the deprecated `github.com/golang/mock`.
 
 #### PATH Configuration
 
@@ -149,7 +141,7 @@ The project uses code generation to create mock implementations for testing. If 
 make generate
 ```
 
-This will regenerate mock files in the `mocks/` directory using `mockgen` from `go.uber.org/mock`.
+This runs `go generate ./...`, which invokes `go tool mockgen` to regenerate the mock files in the `mocks/` directory. `mockgen` is pinned as a `tool` dependency in `go.mod` (`go.uber.org/mock`, the actively maintained fork of `github.com/golang/mock`), so generation is reproducible without installing `mockgen` separately.
 
 **Generated files:**
 - `mocks/mock_autoscaling_client.go`
@@ -178,4 +170,4 @@ This will regenerate mock files in the `mocks/` directory using `mockgen` from `
 - Version information is derived from git tags
 - Mock generation uses `go.uber.org/mock` (the actively maintained fork of gomock), not the deprecated `github.com/golang/mock`
 - Generated mock files should not be manually edited; regenerate them using `make generate`
-- The project requires Go 1.23.0 or later due to modern Go syntax (use of `any` instead of `interface{}`)
+- The project requires Go 1.26.4 or later (the `go` directive in `go.mod`); the `tool` directive needs at least Go 1.24

--- a/autoscaling.go
+++ b/autoscaling.go
@@ -12,7 +12,7 @@ import (
 
 // AutoscalingClient is the subset of the EC2 Auto Scaling API used by the daemon.
 //
-//go:generate mockgen -destination=mocks/mock_autoscaling_client.go -package=mocks github.com/buildkite/lifecycled AutoscalingClient
+//go:generate go tool mockgen -destination=mocks/mock_autoscaling_client.go -package=mocks github.com/buildkite/lifecycled AutoscalingClient
 type AutoscalingClient interface {
 	CompleteLifecycleAction(context.Context, *autoscaling.CompleteLifecycleActionInput, ...func(*autoscaling.Options)) (*autoscaling.CompleteLifecycleActionOutput, error)
 	RecordLifecycleActionHeartbeat(context.Context, *autoscaling.RecordLifecycleActionHeartbeatInput, ...func(*autoscaling.Options)) (*autoscaling.RecordLifecycleActionHeartbeatOutput, error)

--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect
+	golang.org/x/mod v0.27.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/tools v0.36.0 // indirect
 )
+
+tool go.uber.org/mock/mockgen

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/aws/smithy-go v1.27.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqx
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.3 h1:DBBfY8eMYazKEJHb3JKpSPfpgd2mBCoNFlQx6C5fftU=
@@ -58,9 +60,15 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
+golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=
+golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/queue.go
+++ b/queue.go
@@ -37,7 +37,7 @@ const (
 
 // SQSClient is the subset of the SQS API used by the daemon.
 //
-//go:generate mockgen -destination=mocks/mock_sqs_client.go -package=mocks github.com/buildkite/lifecycled SQSClient
+//go:generate go tool mockgen -destination=mocks/mock_sqs_client.go -package=mocks github.com/buildkite/lifecycled SQSClient
 type SQSClient interface {
 	CreateQueue(context.Context, *sqs.CreateQueueInput, ...func(*sqs.Options)) (*sqs.CreateQueueOutput, error)
 	GetQueueAttributes(context.Context, *sqs.GetQueueAttributesInput, ...func(*sqs.Options)) (*sqs.GetQueueAttributesOutput, error)
@@ -48,7 +48,7 @@ type SQSClient interface {
 
 // SNSClient is the subset of the SNS API used by the daemon.
 //
-//go:generate mockgen -destination=mocks/mock_sns_client.go -package=mocks github.com/buildkite/lifecycled SNSClient
+//go:generate go tool mockgen -destination=mocks/mock_sns_client.go -package=mocks github.com/buildkite/lifecycled SNSClient
 type SNSClient interface {
 	Subscribe(context.Context, *sns.SubscribeInput, ...func(*sns.Options)) (*sns.SubscribeOutput, error)
 	Unsubscribe(context.Context, *sns.UnsubscribeInput, ...func(*sns.Options)) (*sns.UnsubscribeOutput, error)


### PR DESCRIPTION
## Summary

Pins `mockgen` as a `go.mod` `tool` dependency and generates the mocks through `go tool mockgen`, so `go generate ./...` (and `make generate`) is reproducible without anyone installing `mockgen` separately or matching its version by hand.

This is a tooling-only change. It does not alter any generated output: `go tool mockgen` runs the same pinned `go.uber.org/mock` version, so the bytes under `mocks/` are unchanged (this PR touches no files in `mocks/`).

Stacks on top of the `aws-sdk-go-v2` upgrade (#115).

## What changed

- `go.mod` declares `tool go.uber.org/mock/mockgen`, which pins the generator and pulls its build-time dependencies (`golang.org/x/mod`, `golang.org/x/sync`, `golang.org/x/tools`) into `go.sum` as indirect requires. The `tool` directive needs Go 1.24 or later; `go.mod` already targets Go 1.26.4.
- The `//go:generate` directives in `queue.go` (`SQSClient`, `SNSClient`) and `autoscaling.go` (`AutoscalingClient`) now call `go tool mockgen` instead of a bare `mockgen`.
- `DEVELOPMENT.md` drops the "install mockgen" step and documents the `go tool mockgen` workflow and the reproducible-generation guarantee.

## Verification

- `go generate ./...` regenerates `mocks/` with no diff against the committed files (`git diff --exit-code` clean), confirming `go tool mockgen` reproduces the existing bytes.
- `go build ./...`, `go vet ./...`, and `go test ./...` pass.
