### PR TITLE
Add golangci-lint, race detector, and generate-sync to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,16 @@
 steps:
+  - label: "🧹"
+    plugins:
+      - golangci-lint#v1.0.0:
+          docker_image: "golangci/golangci-lint:v2.12.2"
+          config: .golangci.yml
+
   - label: "🔎"
-    command: go test ./...
+    commands:
+      - go generate ./...
+      - git diff --exit-code
+      - go test -race ./...
     plugins:
       - golang#v2.0.0:
           version: 1.26.4
           import: github.com/buildkite/lifecycled
-          environment:
-            - GO111MODULE=on

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,10 +6,11 @@ steps:
           config: .golangci.yml
 
   - label: "🔎"
-    commands:
-      - go generate ./...
-      - git diff --exit-code
-      - go test -race ./...
+    command: |
+      set -e
+      go generate ./...
+      git diff --exit-code
+      go test -race ./...
     plugins:
       - golang#v2.0.0:
           version: 1.26.4

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,6 +9,7 @@ steps:
     command: |
       set -e
       go generate ./...
+      git add -N .
       git diff --exit-code
       go test -race ./...
     plugins:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+version: "2"
+
+linters:
+  default: standard

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,6 +143,8 @@ make generate
 
 This runs `go generate ./...`, which invokes `go tool mockgen` to regenerate the mock files in the `mocks/` directory. `mockgen` is pinned as a `tool` dependency in `go.mod` (`go.uber.org/mock`, the actively maintained fork of `github.com/golang/mock`), so generation is reproducible without installing `mockgen` separately.
 
+CI verifies the committed mocks stay in sync by running `go generate ./...` followed by `git diff --exit-code`, so regenerate and commit the result after changing any interface. CI also runs `golangci-lint` (config in `.golangci.yml`) and `go test -race`.
+
 **Generated files:**
 - `mocks/mock_autoscaling_client.go`
 - `mocks/mock_sns_client.go`


### PR DESCRIPTION
## Summary

Adds three CI guardrails for the v2 codebase: `golangci-lint`, the race detector, and a check that the committed mocks match `go generate` output. These catch lint regressions, data races, and stale mocks in CI instead of in review.

Stacks on `chore/go-tool-mockgen` (https://github.com/buildkite/lifecycled/pull/116). The generate-sync step runs `go generate ./...`, which invokes `go tool mockgen`, so it depends on the `tool` directive added by that branch.

## What changed

- New lint step runs `golangci-lint` through the `golangci-lint` Buildkite plugin against the pinned `golangci/golangci-lint:v2.12.2` image and `.golangci.yml`.
- `.golangci.yml` is a minimal golangci-lint v2 config enabling the `standard` linter set.
- The test step now runs `go generate ./...` then `git diff --exit-code`, so the build fails if the committed mocks drift from generated output, followed by `go test -race ./...` in place of the previous plain `go test ./...`.
- Drops the now-unneeded `GO111MODULE=on` environment from the Go plugin step.
- `DEVELOPMENT.md` documents these CI checks alongside the generation workflow.

## Verification

- `go generate ./...` followed by `git diff --exit-code` is clean against the committed mocks.
- `go test -race ./...` passes locally.
- `golangci-lint` runs in CI via the pinned `v2.12.2` image rather than a local install.
