### PR TITLE
Harden autoscaling listener shutdown and heartbeat

### DIFF
--- a/autoscaling.go
+++ b/autoscaling.go
@@ -3,6 +3,7 @@ package lifecycled
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -186,9 +187,7 @@ func (n *autoscalingTerminationNotice) Type() string {
 
 func (n *autoscalingTerminationNotice) Handle(ctx context.Context, handler Handler, log *logrus.Entry) error {
 	defer func() {
-		// Use a fresh, bounded context so the lifecycle action always completes,
-		// even if the handler context was cancelled mid-shutdown, without hanging
-		// indefinitely on an unreachable endpoint.
+		// Fresh, bounded context so completion runs even if ctx was cancelled mid-shutdown.
 		completeCtx, cancel := context.WithTimeout(context.Background(), awsActionTimeout)
 		defer cancel()
 		_, err := n.autoscaling.CompleteLifecycleAction(completeCtx, &autoscaling.CompleteLifecycleActionInput{
@@ -229,7 +228,9 @@ func (n *autoscalingTerminationNotice) Handle(ctx context.Context, handler Handl
 						LifecycleActionToken: aws.String(n.message.ActionToken),
 					},
 				)
-				if err != nil {
+				// A heartbeat cancelled because Handle returned is a clean stop, not
+				// a failure worth logging.
+				if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					log.WithError(err).Warn("Failed to send heartbeat")
 				}
 			}

--- a/autoscaling.go
+++ b/autoscaling.go
@@ -10,14 +10,22 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// sqsErrorBackoff paces the polling loop when GetMessages keeps failing, so a
-// persistent error (throttling, permissions) doesn't spin the loop.
-const sqsErrorBackoff = 5 * time.Second
+const (
+	// sqsErrorBackoff paces the polling loop when GetMessages keeps failing, so a
+	// persistent error (throttling, permissions) doesn't spin the loop.
+	sqsErrorBackoff = 5 * time.Second
 
-// awsActionTimeout bounds the cleanup and lifecycle-completion calls that run on
-// a fresh context during shutdown, so an unreachable endpoint can't wedge the
-// process while leaving room for the SDK's default retries to land.
-const awsActionTimeout = 30 * time.Second
+	// cleanupTimeout bounds the queue and subscription teardown that runs on a
+	// fresh context during shutdown. It is short and shared across both calls so
+	// cleanup can't delay the termination handler or outlast the supervisor's
+	// stop timeout when an endpoint is slow or unreachable.
+	cleanupTimeout = 5 * time.Second
+
+	// awsActionTimeout bounds CompleteLifecycleAction, which runs on a fresh
+	// context after the handler returns, so an unreachable endpoint can't wedge
+	// the process while leaving room for the SDK's default retries to land.
+	awsActionTimeout = 30 * time.Second
+)
 
 // AutoscalingClient is the subset of the EC2 Auto Scaling API used by the daemon.
 //
@@ -76,11 +84,21 @@ func (l *AutoscalingListener) Start(ctx context.Context, notices chan<- Terminat
 	if err := l.queue.Create(ctx); err != nil {
 		return err
 	}
+	subscribed := false
+	// Tear down the subscription and queue on a fresh, bounded context so cleanup
+	// still runs after ctx is cancelled during shutdown, sharing one short deadline
+	// so a slow endpoint can't delay the handler or outlast the supervisor's stop
+	// timeout.
 	defer func() {
-		log.WithField("queue", l.queue.name).Debug("Deleting sqs queue")
-		// Use a fresh, bounded context so cleanup still runs after ctx is cancelled.
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), awsActionTimeout)
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
 		defer cancel()
+		if subscribed {
+			log.WithField("arn", l.queue.subscriptionArn).Debug("Deleting sns subscription")
+			if err := l.queue.Unsubscribe(cleanupCtx); err != nil {
+				log.WithError(err).Error("Failed to unsubscribe from sns topic")
+			}
+		}
+		log.WithField("queue", l.queue.name).Debug("Deleting sqs queue")
 		if err := l.queue.Delete(cleanupCtx); err != nil {
 			log.WithError(err).Error("Failed to delete queue")
 		}
@@ -90,14 +108,7 @@ func (l *AutoscalingListener) Start(ctx context.Context, notices chan<- Terminat
 	if err := l.queue.Subscribe(ctx); err != nil {
 		return err
 	}
-	defer func() {
-		log.WithField("arn", l.queue.subscriptionArn).Debug("Deleting sns subscription")
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), awsActionTimeout)
-		defer cancel()
-		if err := l.queue.Unsubscribe(cleanupCtx); err != nil {
-			log.WithError(err).Error("Failed to unsubscribe from sns topic")
-		}
-	}()
+	subscribed = true
 
 	for {
 		select {

--- a/autoscaling.go
+++ b/autoscaling.go
@@ -10,6 +10,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// sqsErrorBackoff paces the polling loop when GetMessages keeps failing, so a
+// persistent error (throttling, permissions) doesn't spin the loop.
+const sqsErrorBackoff = 5 * time.Second
+
+// awsActionTimeout bounds the cleanup and lifecycle-completion calls that run on
+// a fresh context during shutdown, so an unreachable endpoint can't wedge the
+// process while leaving room for the SDK's default retries to land.
+const awsActionTimeout = 30 * time.Second
+
 // AutoscalingClient is the subset of the EC2 Auto Scaling API used by the daemon.
 //
 //go:generate go tool mockgen -destination=mocks/mock_autoscaling_client.go -package=mocks github.com/buildkite/lifecycled AutoscalingClient
@@ -69,7 +78,10 @@ func (l *AutoscalingListener) Start(ctx context.Context, notices chan<- Terminat
 	}
 	defer func() {
 		log.WithField("queue", l.queue.name).Debug("Deleting sqs queue")
-		if err := l.queue.Delete(ctx); err != nil {
+		// Use a fresh, bounded context so cleanup still runs after ctx is cancelled.
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), awsActionTimeout)
+		defer cancel()
+		if err := l.queue.Delete(cleanupCtx); err != nil {
 			log.WithError(err).Error("Failed to delete queue")
 		}
 	}()
@@ -80,7 +92,9 @@ func (l *AutoscalingListener) Start(ctx context.Context, notices chan<- Terminat
 	}
 	defer func() {
 		log.WithField("arn", l.queue.subscriptionArn).Debug("Deleting sns subscription")
-		if err := l.queue.Unsubscribe(ctx); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), awsActionTimeout)
+		defer cancel()
+		if err := l.queue.Unsubscribe(cleanupCtx); err != nil {
 			log.WithError(err).Error("Failed to unsubscribe from sns topic")
 		}
 	}()
@@ -94,6 +108,12 @@ func (l *AutoscalingListener) Start(ctx context.Context, notices chan<- Terminat
 			messages, err := l.queue.GetMessages(ctx)
 			if err != nil {
 				log.WithError(err).Warn("Failed to get messages from SQS")
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(sqsErrorBackoff):
+				}
+				continue
 			}
 			for _, m := range messages {
 				var env Envelope
@@ -155,7 +175,12 @@ func (n *autoscalingTerminationNotice) Type() string {
 
 func (n *autoscalingTerminationNotice) Handle(ctx context.Context, handler Handler, log *logrus.Entry) error {
 	defer func() {
-		_, err := n.autoscaling.CompleteLifecycleAction(ctx, &autoscaling.CompleteLifecycleActionInput{
+		// Use a fresh, bounded context so the lifecycle action always completes,
+		// even if the handler context was cancelled mid-shutdown, without hanging
+		// indefinitely on an unreachable endpoint.
+		completeCtx, cancel := context.WithTimeout(context.Background(), awsActionTimeout)
+		defer cancel()
+		_, err := n.autoscaling.CompleteLifecycleAction(completeCtx, &autoscaling.CompleteLifecycleActionInput{
 			AutoScalingGroupName:  aws.String(n.message.GroupName),
 			LifecycleHookName:     aws.String(n.message.HookName),
 			InstanceId:            aws.String(n.message.InstanceID),
@@ -172,20 +197,30 @@ func (n *autoscalingTerminationNotice) Handle(ctx context.Context, handler Handl
 	ticker := time.NewTicker(n.heartbeatInterval)
 	defer ticker.Stop()
 
+	// Stop the heartbeat goroutine when Handle returns; ticker.Stop alone doesn't
+	// close the channel, so a bare "for range ticker.C" would park forever.
+	heartbeatCtx, stopHeartbeat := context.WithCancel(ctx)
+	defer stopHeartbeat()
+
 	go func() {
-		for range ticker.C {
-			log.Debug("Sending heartbeat")
-			_, err := n.autoscaling.RecordLifecycleActionHeartbeat(
-				ctx,
-				&autoscaling.RecordLifecycleActionHeartbeatInput{
-					AutoScalingGroupName: aws.String(n.message.GroupName),
-					LifecycleHookName:    aws.String(n.message.HookName),
-					InstanceId:           aws.String(n.message.InstanceID),
-					LifecycleActionToken: aws.String(n.message.ActionToken),
-				},
-			)
-			if err != nil {
-				log.WithError(err).Warn("Failed to send heartbeat")
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+				log.Debug("Sending heartbeat")
+				_, err := n.autoscaling.RecordLifecycleActionHeartbeat(
+					heartbeatCtx,
+					&autoscaling.RecordLifecycleActionHeartbeatInput{
+						AutoScalingGroupName: aws.String(n.message.GroupName),
+						LifecycleHookName:    aws.String(n.message.HookName),
+						InstanceId:           aws.String(n.message.InstanceID),
+						LifecycleActionToken: aws.String(n.message.ActionToken),
+					},
+				)
+				if err != nil {
+					log.WithError(err).Warn("Failed to send heartbeat")
+				}
 			}
 		}
 	}()

--- a/autoscaling_test.go
+++ b/autoscaling_test.go
@@ -16,13 +16,16 @@ import (
 )
 
 // stubSQSClient drives the autoscaling listener's queue without real AWS. Create
-// and Subscribe always succeed; ReceiveMessage returns receiveErr and counts how
-// often it was called so a test can tell a backed-off loop from a spinning one;
-// DeleteQueue returns deleteQueueErr so queue tests can exercise its error paths.
+// always succeeds; ReceiveMessage returns receiveErr and counts how often it was
+// called so a test can tell a backed-off loop from a spinning one; DeleteQueue
+// returns deleteQueueErr, counts calls, and records whether its context carried a
+// deadline so a test can assert cleanup runs on a bounded context.
 type stubSQSClient struct {
-	receiveErr     error
-	receiveCalls   int64
-	deleteQueueErr error
+	receiveErr             error
+	receiveCalls           int64
+	deleteQueueErr         error
+	deleteQueueCalls       int64
+	deleteQueueHadDeadline bool
 }
 
 func (s *stubSQSClient) CreateQueue(context.Context, *sqs.CreateQueueInput, ...func(*sqs.Options)) (*sqs.CreateQueueOutput, error) {
@@ -45,20 +48,30 @@ func (s *stubSQSClient) DeleteMessage(context.Context, *sqs.DeleteMessageInput, 
 	return &sqs.DeleteMessageOutput{}, nil
 }
 
-func (s *stubSQSClient) DeleteQueue(context.Context, *sqs.DeleteQueueInput, ...func(*sqs.Options)) (*sqs.DeleteQueueOutput, error) {
+func (s *stubSQSClient) DeleteQueue(ctx context.Context, _ *sqs.DeleteQueueInput, _ ...func(*sqs.Options)) (*sqs.DeleteQueueOutput, error) {
+	_, s.deleteQueueHadDeadline = ctx.Deadline()
+	atomic.AddInt64(&s.deleteQueueCalls, 1)
 	if s.deleteQueueErr != nil {
 		return nil, s.deleteQueueErr
 	}
 	return &sqs.DeleteQueueOutput{}, nil
 }
 
-type stubSNSClient struct{}
+// stubSNSClient counts Unsubscribe calls and records whether its context carried
+// a deadline, so a test can assert the subscription teardown runs on a bounded
+// context during shutdown.
+type stubSNSClient struct {
+	unsubscribeCalls       int64
+	unsubscribeHadDeadline bool
+}
 
-func (stubSNSClient) Subscribe(context.Context, *sns.SubscribeInput, ...func(*sns.Options)) (*sns.SubscribeOutput, error) {
+func (*stubSNSClient) Subscribe(context.Context, *sns.SubscribeInput, ...func(*sns.Options)) (*sns.SubscribeOutput, error) {
 	return &sns.SubscribeOutput{SubscriptionArn: aws.String("arn")}, nil
 }
 
-func (stubSNSClient) Unsubscribe(context.Context, *sns.UnsubscribeInput, ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
+func (s *stubSNSClient) Unsubscribe(ctx context.Context, _ *sns.UnsubscribeInput, _ ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
+	_, s.unsubscribeHadDeadline = ctx.Deadline()
+	atomic.AddInt64(&s.unsubscribeCalls, 1)
 	return &sns.UnsubscribeOutput{}, nil
 }
 
@@ -99,7 +112,7 @@ func (h sleepHandler) Execute(ctx context.Context, _ ...string) error {
 // return promptly when the context is cancelled mid-backoff.
 func TestAutoscalingListenerBacksOffOnReceiveError(t *testing.T) {
 	sqsStub := &stubSQSClient{receiveErr: errors.New("throttled")}
-	queue := NewQueue("queue", "topic", sqsStub, stubSNSClient{}, "")
+	queue := NewQueue("queue", "topic", sqsStub, &stubSNSClient{}, "")
 	listener := NewAutoscalingListener("i-1234567890", queue, &stubAutoscalingClient{}, time.Minute)
 
 	logger, _ := logrustest.NewNullLogger()
@@ -126,6 +139,50 @@ func TestAutoscalingListenerBacksOffOnReceiveError(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Start did not return after cancel; the backoff select may ignore ctx.Done()")
+	}
+}
+
+// Cleanup must run even after the parent context is cancelled during shutdown, and
+// it must run on a fresh bounded context so a slow endpoint can't wedge shutdown
+// or (on the notice path) delay the handler.
+func TestAutoscalingListenerCleanupRunsOnBoundedContext(t *testing.T) {
+	sqsStub := &stubSQSClient{}
+	snsStub := &stubSNSClient{}
+	queue := NewQueue("queue", "topic", sqsStub, snsStub, "")
+	listener := NewAutoscalingListener("i-1234567890", queue, &stubAutoscalingClient{}, time.Minute)
+
+	logger, _ := logrustest.NewNullLogger()
+	notices := make(chan TerminationNotice, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- listener.Start(ctx, notices, logrus.NewEntry(logger)) }()
+
+	// Let the listener get past Create/Subscribe into the poll loop, so the cleanup
+	// defer is registered with subscribed == true before we cancel.
+	waitFor(t, func() bool { return atomic.LoadInt64(&sqsStub.receiveCalls) >= 1 })
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+
+	if got := atomic.LoadInt64(&snsStub.unsubscribeCalls); got != 1 {
+		t.Errorf("Unsubscribe called %d times, want 1; cleanup must run after ctx is cancelled", got)
+	}
+	if got := atomic.LoadInt64(&sqsStub.deleteQueueCalls); got != 1 {
+		t.Errorf("DeleteQueue called %d times, want 1; cleanup must run after ctx is cancelled", got)
+	}
+	if !snsStub.unsubscribeHadDeadline {
+		t.Error("Unsubscribe context had no deadline; cleanup must be bounded by a timeout")
+	}
+	if !sqsStub.deleteQueueHadDeadline {
+		t.Error("DeleteQueue context had no deadline; cleanup must be bounded by a timeout")
 	}
 }
 

--- a/autoscaling_test.go
+++ b/autoscaling_test.go
@@ -2,17 +2,23 @@ package lifecycled
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
+	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 )
 
 // stubSQSClient drives the autoscaling listener's queue without real AWS. Create
 // and Subscribe always succeed; ReceiveMessage returns receiveErr and counts how
-// often it was called; DeleteQueue returns deleteQueueErr so queue tests can
-// exercise its error paths.
+// often it was called so a test can tell a backed-off loop from a spinning one;
+// DeleteQueue returns deleteQueueErr so queue tests can exercise its error paths.
 type stubSQSClient struct {
 	receiveErr     error
 	receiveCalls   int64
@@ -54,4 +60,131 @@ func (stubSNSClient) Subscribe(context.Context, *sns.SubscribeInput, ...func(*sn
 
 func (stubSNSClient) Unsubscribe(context.Context, *sns.UnsubscribeInput, ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
 	return &sns.UnsubscribeOutput{}, nil
+}
+
+// stubAutoscalingClient counts heartbeat and completion calls and records whether
+// the completion call was given a deadline.
+type stubAutoscalingClient struct {
+	heartbeats          int64
+	completes           int64
+	completeHadDeadline bool
+}
+
+func (s *stubAutoscalingClient) RecordLifecycleActionHeartbeat(context.Context, *autoscaling.RecordLifecycleActionHeartbeatInput, ...func(*autoscaling.Options)) (*autoscaling.RecordLifecycleActionHeartbeatOutput, error) {
+	atomic.AddInt64(&s.heartbeats, 1)
+	return &autoscaling.RecordLifecycleActionHeartbeatOutput{}, nil
+}
+
+func (s *stubAutoscalingClient) CompleteLifecycleAction(ctx context.Context, _ *autoscaling.CompleteLifecycleActionInput, _ ...func(*autoscaling.Options)) (*autoscaling.CompleteLifecycleActionOutput, error) {
+	_, s.completeHadDeadline = ctx.Deadline()
+	atomic.AddInt64(&s.completes, 1)
+	return &autoscaling.CompleteLifecycleActionOutput{}, nil
+}
+
+// sleepHandler runs for d (or until the context is cancelled) so heartbeats have
+// time to fire while the handler is executing.
+type sleepHandler struct {
+	d time.Duration
+}
+
+func (h sleepHandler) Execute(ctx context.Context, _ ...string) error {
+	select {
+	case <-time.After(h.d):
+	case <-ctx.Done():
+	}
+	return nil
+}
+
+// A persistently failing GetMessages must back off rather than spin, and must
+// return promptly when the context is cancelled mid-backoff.
+func TestAutoscalingListenerBacksOffOnReceiveError(t *testing.T) {
+	sqsStub := &stubSQSClient{receiveErr: errors.New("throttled")}
+	queue := NewQueue("queue", "topic", sqsStub, stubSNSClient{}, "")
+	listener := NewAutoscalingListener("i-1234567890", queue, &stubAutoscalingClient{}, time.Minute)
+
+	logger, _ := logrustest.NewNullLogger()
+	notices := make(chan TerminationNotice, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- listener.Start(ctx, notices, logrus.NewEntry(logger)) }()
+
+	// The first failure parks the loop in the backoff select; without the backoff
+	// the loop would spin and rack up ReceiveMessage calls.
+	waitFor(t, func() bool { return atomic.LoadInt64(&sqsStub.receiveCalls) >= 1 })
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt64(&sqsStub.receiveCalls); got > 2 {
+		t.Errorf("ReceiveMessage called %d times; the backoff should leave the loop parked after the first failure", got)
+	}
+
+	// Cancelling must break the backoff select well before the 5s timer elapses.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after cancel; the backoff select may ignore ctx.Done()")
+	}
+}
+
+// The heartbeat goroutine must stop once Handle returns, and the lifecycle action
+// must be completed exactly once.
+func TestAutoscalingNoticeStopsHeartbeatWhenHandleReturns(t *testing.T) {
+	as := &stubAutoscalingClient{}
+	notice := &autoscalingTerminationNotice{
+		noticeType: "autoscaling",
+		message: &Message{
+			GroupName:   "group",
+			HookName:    "hook",
+			InstanceID:  "i-1234567890",
+			ActionToken: "token",
+			Transition:  "autoscaling:EC2_INSTANCE_TERMINATING",
+		},
+		autoscaling:       as,
+		heartbeatInterval: 10 * time.Millisecond,
+	}
+	logger, _ := logrustest.NewNullLogger()
+
+	if err := notice.Handle(context.Background(), sleepHandler{d: 60 * time.Millisecond}, logrus.NewEntry(logger)); err != nil {
+		t.Fatalf("Handle returned error: %v", err)
+	}
+
+	during := atomic.LoadInt64(&as.heartbeats)
+	if during == 0 {
+		t.Fatal("expected at least one heartbeat while the handler was running")
+	}
+
+	// If the goroutine outlived Handle it would keep ticking; allow one racy tick
+	// from the select that may already have been in flight when Handle returned.
+	time.Sleep(60 * time.Millisecond)
+	if after := atomic.LoadInt64(&as.heartbeats); after-during > 1 {
+		t.Errorf("heartbeats kept firing after Handle returned (%d during, %d after); goroutine not stopped", during, after)
+	}
+
+	if got := atomic.LoadInt64(&as.completes); got != 1 {
+		t.Errorf("CompleteLifecycleAction called %d times, want 1", got)
+	}
+
+	// The completion runs on a fresh context during shutdown; it must be bounded
+	// by a timeout so an unreachable endpoint can't wedge the process.
+	if !as.completeHadDeadline {
+		t.Error("CompleteLifecycleAction context had no deadline; the completion call must be bounded by a timeout")
+	}
+}
+
+// waitFor polls cond until it is true, failing the test if it does not happen
+// within a couple of seconds. Lets timing tests advance on observed progress
+// rather than fixed sleeps.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for condition")
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -270,7 +270,7 @@ func TestQueueGetMessages(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			q := NewQueue("queue", "topic", &stubSQSClient{receiveErr: tc.receiveErr}, stubSNSClient{}, "")
+			q := NewQueue("queue", "topic", &stubSQSClient{receiveErr: tc.receiveErr}, &stubSNSClient{}, "")
 			msgs, err := q.GetMessages(context.Background())
 
 			if tc.wantErr == nil {
@@ -306,7 +306,7 @@ func TestQueueDelete(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			q := NewQueue("queue", "topic", &stubSQSClient{deleteQueueErr: tc.deleteQueueErr}, stubSNSClient{}, "")
+			q := NewQueue("queue", "topic", &stubSQSClient{deleteQueueErr: tc.deleteQueueErr}, &stubSNSClient{}, "")
 			err := q.Delete(context.Background())
 
 			if tc.wantErr == nil {

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -109,7 +109,9 @@ var credentialExpiryCodes = map[string]struct{}{
 
 // fatalAWS ends the run, adding a re-auth hint when the failure is expired
 // credentials. Re-running is safe: each run re-lists from scratch and resumes
-// where the last left off.
+// where the last left off. Aborting on any AWS error (rather than skipping the
+// offending resource) is deliberate: the SDK already retries transient failures,
+// so an error reaching here is unexpected and worth stopping on.
 func fatalAWS(err error) {
 	if apiErr, expired := expiredCredential(err); expired {
 		log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", apiErr.ErrorCode(), err)

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -50,7 +50,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to resolve caller identity: %s", err)
 	}
-	if *account != "" && *account != aws.ToString(ident.Account) {
+	if !accountMatches(*account, aws.ToString(ident.Account)) {
 		log.Fatalf("Resolved account %s does not match the expected account %s", aws.ToString(ident.Account), *account)
 	}
 	log.Printf("Using account %s as %s", aws.ToString(ident.Account), aws.ToString(ident.Arn))
@@ -63,10 +63,9 @@ func main() {
 
 		if count == 0 {
 			break
-		} else {
-			log.Printf("Deleted %d subscriptions, running again as aws limits subscriptions returned to 100", count)
-			time.Sleep(time.Second * 2)
 		}
+		log.Printf("Deleted %d subscriptions, running again as aws limits subscriptions returned to 100", count)
+		time.Sleep(time.Second * 2)
 	}
 
 	for {
@@ -77,10 +76,9 @@ func main() {
 
 		if count == 0 {
 			break
-		} else {
-			log.Printf("Deleted %d queues, running again as aws limits queues returned to 1000", count)
-			time.Sleep(time.Second * 60)
 		}
+		log.Printf("Deleted %d queues, running again until a pass finds none", count)
+		time.Sleep(time.Second * 60)
 	}
 
 	log.Printf("Done! Sorry for the inconvenience!")
@@ -92,6 +90,12 @@ func callerIdentity(ctx context.Context, client *sts.Client) (*sts.GetCallerIden
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	return client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+}
+
+// accountMatches reports whether the resolved account satisfies the --account
+// guard. An empty expected means no guard was requested.
+func accountMatches(expected, resolved string) bool {
+	return expected == "" || expected == resolved
 }
 
 // credentialExpiryCodes are the AWS error codes meaning the credentials
@@ -107,61 +111,86 @@ var credentialExpiryCodes = map[string]struct{}{
 // credentials. Re-running is safe: each run re-lists from scratch and resumes
 // where the last left off.
 func fatalAWS(err error) {
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		if _, expired := credentialExpiryCodes[apiErr.ErrorCode()]; expired {
-			log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", apiErr.ErrorCode(), err)
-		}
+	if apiErr, expired := expiredCredential(err); expired {
+		log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", apiErr.ErrorCode(), err)
 	}
 	log.Fatal(err)
+}
+
+// expiredCredential returns the AWS API error and true when its code means the
+// credentials (temporary STS credentials or the cached SSO token) expired.
+func expiredCredential(err error) (smithy.APIError, bool) {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return nil, false
+	}
+	_, expired := credentialExpiryCodes[apiErr.ErrorCode()]
+	return apiErr, expired
 }
 
 func deleteInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *ec2.Client, parallel int) (uint64, error) {
 	queues, err := listInactiveQueues(ctx, sqsClient, ec2Client)
 	if err != nil {
-		fatalAWS(err)
+		return 0, err
 	}
+	return deleteQueues(queues, parallel, func(queue string) error {
+		return deleteQueue(ctx, sqsClient, queue)
+	})
+}
 
+// deleteQueues deletes queues using up to parallel workers. It stops at the
+// first error, returning 0 and that error; on success it returns the number
+// processed. deleteFn is expected to treat an already-deleted queue as success.
+func deleteQueues(queues []string, parallel int, deleteFn func(string) error) (uint64, error) {
+	if parallel < 1 {
+		parallel = 1
+	}
 	var wg sync.WaitGroup
 	var count uint64
-	var queuesCh = make(chan string)
-	var errCh = make(chan error)
+	queuesCh := make(chan string)
+	// Buffer to the worker count so a worker that errors after the dispatch
+	// loop has stopped reading errCh never blocks on the send (goroutine leak).
+	errCh := make(chan error, parallel)
 
-	// spawn parallel workers
+	wg.Add(parallel)
 	for i := 0; i < parallel; i++ {
-		go func(total int) {
+		go func() {
+			defer wg.Done()
 			for queue := range queuesCh {
-				atomic.AddUint64(&count, 1)
-				log.Printf("Deleting %s (%d of %d)", queue, count, total)
-				err := deleteQueue(ctx, sqsClient, queue)
-				wg.Done()
-				var notExist *sqstypes.QueueDoesNotExist
-				if errors.As(err, &notExist) {
-					continue
-				}
-				if err != nil {
+				n := atomic.AddUint64(&count, 1)
+				log.Printf("Deleting %s (%d of %d)", queue, n, len(queues))
+				if err := deleteFn(queue); err != nil {
 					errCh <- err
 					return
 				}
 			}
-		}(len(queues))
+		}()
 	}
 
-	// dispatch work to parallel workers
+	// dispatch work, stopping early once a worker reports an error
+	var err error
 	for _, queue := range queues {
 		select {
 		case queuesCh <- queue:
-			wg.Add(1)
-		case err := <-errCh:
-			close(queuesCh)
-			return 0, err
+		case err = <-errCh:
+		}
+		if err != nil {
+			break
 		}
 	}
-
-	// wait for work to finish
-	wg.Wait()
 	close(queuesCh)
+	wg.Wait()
 
+	if err == nil {
+		// Surface an error from a worker that finished after dispatch ended.
+		select {
+		case err = <-errCh:
+		default:
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
 	return count, nil
 }
 
@@ -195,21 +224,26 @@ func listInstances(ctx context.Context, client *ec2.Client) ([]string, error) {
 }
 
 func listQueues(ctx context.Context, client *sqs.Client) ([]string, error) {
-	resp, err := client.ListQueues(ctx, &sqs.ListQueuesInput{
+	var urls []string
+	paginator := sqs.NewListQueuesPaginator(client, &sqs.ListQueuesInput{
 		QueueNamePrefix: aws.String(`lifecycled-`),
 	})
-	if err != nil {
-		return nil, err
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, page.QueueUrls...)
 	}
-	return resp.QueueUrls, nil
+	return urls, nil
 }
 
-var queueRegex = regexp.MustCompile(`^https://sqs\.(.+?)\.amazonaws.com/(.+?)/lifecycled-(i-.+)$`)
+var queueRegex = regexp.MustCompile(`^https://sqs\.(.+?)\.amazonaws\.com(?:\.cn)?/(.+?)/lifecycled-(i-.+)$`)
 
 func listInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *ec2.Client) ([]string, error) {
 	instances, err := listInstances(ctx, ec2Client)
 	if err != nil {
-		fatalAWS(err)
+		return nil, err
 	}
 
 	log.Printf("Found %d running instances", len(instances))
@@ -222,36 +256,56 @@ func listInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *e
 
 	queues, err := listQueues(ctx, sqsClient)
 	if err != nil {
-		fatalAWS(err)
+		return nil, err
 	}
 
-	log.Printf("Found %d queues total (aws returns max 1000)", len(queues))
+	log.Printf("Found %d lifecycled queues total", len(queues))
 
-	var inactiveQueues []string
-	for _, queue := range queues {
-		matches := queueRegex.FindStringSubmatch(queue)
-		if len(matches) != 4 {
-			continue
-		}
-		instanceID := matches[3]
-		if _, exists := instancesMap[instanceID]; !exists {
-			inactiveQueues = append(inactiveQueues, queue)
-		}
-	}
+	inactiveQueues := filterInactiveQueues(queues, instancesMap)
 
 	log.Printf("Found %d inactive queues", len(inactiveQueues))
 
 	return inactiveQueues, nil
 }
 
+// filterInactiveQueues returns the lifecycled- queue URLs whose instance id is
+// not in running. URLs that don't match the lifecycled- naming scheme are ignored.
+func filterInactiveQueues(urls []string, running map[string]struct{}) []string {
+	var inactive []string
+	for _, queue := range urls {
+		matches := queueRegex.FindStringSubmatch(queue)
+		if len(matches) != 4 {
+			continue
+		}
+		instanceID := matches[3]
+		if _, exists := running[instanceID]; !exists {
+			inactive = append(inactive, queue)
+		}
+	}
+	return inactive
+}
+
 func deleteQueue(ctx context.Context, client *sqs.Client, queueURL string) error {
 	_, err := client.DeleteQueue(ctx, &sqs.DeleteQueueInput{
 		QueueUrl: aws.String(queueURL),
 	})
+	var notExist *sqstypes.QueueDoesNotExist
+	if errors.As(err, &notExist) {
+		// Already gone; deleting a non-existent queue is success.
+		return nil
+	}
 	return err
 }
 
-func topicExists(ctx context.Context, client *sns.Client, snsTopic string) (bool, error) {
+// SNSClient is the subset of the SNS client the subscription cleanup uses, so the
+// cleanup logic can be exercised with a fake in tests.
+type SNSClient interface {
+	ListSubscriptions(context.Context, *sns.ListSubscriptionsInput, ...func(*sns.Options)) (*sns.ListSubscriptionsOutput, error)
+	GetTopicAttributes(context.Context, *sns.GetTopicAttributesInput, ...func(*sns.Options)) (*sns.GetTopicAttributesOutput, error)
+	Unsubscribe(context.Context, *sns.UnsubscribeInput, ...func(*sns.Options)) (*sns.UnsubscribeOutput, error)
+}
+
+func topicExists(ctx context.Context, client SNSClient, snsTopic string) (bool, error) {
 	_, err := client.GetTopicAttributes(ctx, &sns.GetTopicAttributesInput{
 		TopicArn: aws.String(snsTopic),
 	})
@@ -266,7 +320,7 @@ func topicExists(ctx context.Context, client *sns.Client, snsTopic string) (bool
 	return true, nil
 }
 
-func listInactiveSubscriptions(ctx context.Context, client *sns.Client) ([]string, error) {
+func listInactiveSubscriptions(ctx context.Context, client SNSClient) ([]string, error) {
 	var subs []string
 	var topics = map[string]bool{}
 	var count int
@@ -289,7 +343,14 @@ func listInactiveSubscriptions(ctx context.Context, client *sns.Client) ([]strin
 				}
 				continue
 			}
-			if exists, _ := topicExists(ctx, client, topicArn); exists {
+			exists, err := topicExists(ctx, client, topicArn)
+			if err != nil {
+				// A non-NotFound lookup failure (throttling, AccessDenied, expired
+				// creds) must not be read as "topic gone": abort rather than risk
+				// unsubscribing live subscriptions.
+				return nil, err
+			}
+			if exists {
 				topics[topicArn] = true
 			} else {
 				topics[topicArn] = false
@@ -302,7 +363,7 @@ func listInactiveSubscriptions(ctx context.Context, client *sns.Client) ([]strin
 	return subs, nil
 }
 
-func deleteInactiveSubscriptions(ctx context.Context, client *sns.Client) (int, error) {
+func deleteInactiveSubscriptions(ctx context.Context, client SNSClient) (int, error) {
 	subs, err := listInactiveSubscriptions(ctx, client)
 	if err != nil {
 		return 0, err

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -167,9 +167,18 @@ func deleteQueues(queues []string, parallel int, deleteFn func(string) error) (u
 		}()
 	}
 
-	// dispatch work, stopping early once a worker reports an error
+	// dispatch work, stopping as soon as a worker reports an error. The
+	// pre-send check keeps a buffered error from losing the select race to a
+	// ready send, which would otherwise dispatch more work after the failure.
 	var err error
 	for _, queue := range queues {
+		select {
+		case err = <-errCh:
+		default:
+		}
+		if err != nil {
+			break
+		}
 		select {
 		case queuesCh <- queue:
 		case err = <-errCh:

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -225,8 +225,11 @@ func listInstances(ctx context.Context, client *ec2.Client) ([]string, error) {
 
 func listQueues(ctx context.Context, client *sqs.Client) ([]string, error) {
 	var urls []string
+	// MaxResults is required for SQS to return a NextToken; without it the
+	// response caps at 1000 URLs and the paginator stops after one page.
 	paginator := sqs.NewListQueuesPaginator(client, &sqs.ListQueuesInput{
 		QueueNamePrefix: aws.String(`lifecycled-`),
+		MaxResults:      aws.Int32(1000),
 	})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -234,7 +234,14 @@ func listInstances(ctx context.Context, client *ec2.Client) ([]string, error) {
 	return instances, nil
 }
 
-func listQueues(ctx context.Context, client *sqs.Client) ([]string, error) {
+// SQSClient is the subset of the SQS client the queue cleanup uses, so the
+// listing and delete logic can be exercised with a fake in tests.
+type SQSClient interface {
+	ListQueues(context.Context, *sqs.ListQueuesInput, ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+	DeleteQueue(context.Context, *sqs.DeleteQueueInput, ...func(*sqs.Options)) (*sqs.DeleteQueueOutput, error)
+}
+
+func listQueues(ctx context.Context, client SQSClient) ([]string, error) {
 	var urls []string
 	// MaxResults is required for SQS to return a NextToken; without it the
 	// response caps at 1000 URLs and the paginator stops after one page.
@@ -299,7 +306,7 @@ func filterInactiveQueues(urls []string, running map[string]struct{}) []string {
 	return inactive
 }
 
-func deleteQueue(ctx context.Context, client *sqs.Client, queueURL string) error {
+func deleteQueue(ctx context.Context, client SQSClient, queueURL string) error {
 	_, err := client.DeleteQueue(ctx, &sqs.DeleteQueueInput{
 		QueueUrl: aws.String(queueURL),
 	})

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -139,6 +139,15 @@ func TestDeleteQueues(t *testing.T) {
 			failOn:   "q2",
 			wantErr:  sentinel,
 		},
+		{
+			// One queue, one worker: dispatch sends and exits before the worker
+			// reports, so the error surfaces via the post-Wait drain.
+			name:     "surfaces an error from the drain path",
+			queues:   []string{"q1"},
+			parallel: 1,
+			failOn:   "q1",
+			wantErr:  sentinel,
+		},
 	}
 
 	for _, tt := range tests {
@@ -175,6 +184,7 @@ type fakeSNS struct {
 	subs         []snstypes.Subscription
 	existing     map[string]bool
 	topicErr     map[string]error
+	unsubErr     map[string]error // per-subscription Unsubscribe error
 	topicCalls   int
 	unsubscribed []string
 }
@@ -196,7 +206,11 @@ func (f *fakeSNS) GetTopicAttributes(_ context.Context, in *sns.GetTopicAttribut
 }
 
 func (f *fakeSNS) Unsubscribe(_ context.Context, in *sns.UnsubscribeInput, _ ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
-	f.unsubscribed = append(f.unsubscribed, aws.ToString(in.SubscriptionArn))
+	arn := aws.ToString(in.SubscriptionArn)
+	if err := f.unsubErr[arn]; err != nil {
+		return nil, err
+	}
+	f.unsubscribed = append(f.unsubscribed, arn)
 	return &sns.UnsubscribeOutput{}, nil
 }
 
@@ -214,6 +228,7 @@ func TestListInactiveSubscriptions(t *testing.T) {
 			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
 			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead2", "topic-gone", "sub-dead2"),
 			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live", "topic-live", "sub-live"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live2", "topic-live", "sub-live2"),
 			newSub("arn:aws:sqs:us-east-1:123456789012:some-other-queue", "topic-gone", "sub-other"),
 		},
 		existing: map[string]bool{"topic-live": true},
@@ -228,9 +243,9 @@ func TestListInactiveSubscriptions(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Errorf("listInactiveSubscriptions() = %v, want %v", got, want)
 	}
-	// topic-gone and topic-live are queried once each; the second lifecycled-i
-	// subscription on topic-gone is answered from the memo, and the non-lifecycled
-	// endpoint is filtered out before any topic lookup.
+	// topic-gone and topic-live are queried once each; the second subscription on
+	// each topic is answered from the memo (the dead one is queued, the live one
+	// is skipped), and the non-lifecycled endpoint is filtered out before any lookup.
 	if fake.topicCalls != 2 {
 		t.Errorf("GetTopicAttributes calls = %d, want 2 (memoized per topic)", fake.topicCalls)
 	}
@@ -254,6 +269,25 @@ func TestDeleteInactiveSubscriptions(t *testing.T) {
 	}
 	if !slices.Equal(fake.unsubscribed, []string{"sub-dead"}) {
 		t.Errorf("unsubscribed = %v, want [sub-dead]", fake.unsubscribed)
+	}
+}
+
+func TestDeleteInactiveSubscriptionsUnsubscribeError(t *testing.T) {
+	boom := errors.New("unsubscribe failed")
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead2", "topic-gone", "sub-dead2"),
+		},
+		unsubErr: map[string]error{"sub-dead": boom},
+	}
+
+	count, err := deleteInactiveSubscriptions(context.Background(), fake)
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want %v", err, boom)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (aborts on the first unsubscribe failure)", count)
 	}
 }
 

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/aws/smithy-go"
+)
+
+func TestFilterInactiveQueues(t *testing.T) {
+	const (
+		dead    = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-dead"
+		running = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-running"
+		other   = "https://sqs.us-east-1.amazonaws.com/123456789012/some-other-queue"
+		chinaCN = "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/lifecycled-i-dead"
+	)
+	runningSet := map[string]struct{}{"i-running": {}}
+
+	tests := []struct {
+		name string
+		urls []string
+		want []string
+	}{
+		{name: "empty input", urls: nil, want: nil},
+		{name: "keeps queue for terminated instance", urls: []string{dead}, want: []string{dead}},
+		{name: "skips queue for running instance", urls: []string{running}, want: nil},
+		{name: "ignores non-lifecycled queue", urls: []string{other}, want: nil},
+		{name: "matches china partition url", urls: []string{chinaCN}, want: []string{chinaCN}},
+		{name: "mixed", urls: []string{dead, running, other}, want: []string{dead}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterInactiveQueues(tt.urls, runningSet); !slices.Equal(got, tt.want) {
+				t.Errorf("filterInactiveQueues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAccountMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		resolved string
+		want     bool
+	}{
+		{name: "no guard requested", expected: "", resolved: "123456789012", want: true},
+		{name: "match", expected: "123456789012", resolved: "123456789012", want: true},
+		{name: "mismatch", expected: "123456789012", resolved: "999999999999", want: false},
+		{name: "guard set but account unresolved aborts", expected: "123456789012", resolved: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accountMatches(tt.expected, tt.resolved); got != tt.want {
+				t.Errorf("accountMatches(%q, %q) = %v, want %v", tt.expected, tt.resolved, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpiredCredential(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "non-API error", err: errors.New("boom"), want: false},
+		{name: "other API error", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+		{name: "ExpiredToken", err: &smithy.GenericAPIError{Code: "ExpiredToken"}, want: true},
+		{name: "ExpiredTokenException", err: &smithy.GenericAPIError{Code: "ExpiredTokenException"}, want: true},
+		{name: "RequestExpired", err: &smithy.GenericAPIError{Code: "RequestExpired"}, want: true},
+		{name: "SSOProviderInvalidToken", err: &smithy.GenericAPIError{Code: "SSOProviderInvalidToken"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, got := expiredCredential(tt.err); got != tt.want {
+				t.Errorf("expiredCredential() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteQueues(t *testing.T) {
+	sentinel := errors.New("delete failed")
+	tests := []struct {
+		name      string
+		queues    []string
+		parallel  int
+		failOn    string
+		wantCount uint64
+		wantErr   error
+	}{
+		{
+			name:      "deletes all queues",
+			queues:    []string{"q1", "q2", "q3", "q4", "q5"},
+			parallel:  3,
+			wantCount: 5,
+		},
+		{
+			name:     "no queues",
+			queues:   nil,
+			parallel: 3,
+		},
+		{
+			name:      "fewer queues than workers",
+			queues:    []string{"q1", "q2"},
+			parallel:  10,
+			wantCount: 2,
+		},
+		{
+			name:      "single worker",
+			queues:    []string{"q1", "q2", "q3"},
+			parallel:  1,
+			wantCount: 3,
+		},
+		{
+			name:      "non-positive parallel is clamped to one worker",
+			queues:    []string{"q1", "q2", "q3"},
+			parallel:  0,
+			wantCount: 3,
+		},
+		{
+			name:     "surfaces a delete error",
+			queues:   []string{"q1", "q2", "q3"},
+			parallel: 2,
+			failOn:   "q2",
+			wantErr:  sentinel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleted int64
+			count, err := deleteQueues(tt.queues, tt.parallel, func(queue string) error {
+				atomic.AddInt64(&deleted, 1)
+				if tt.failOn != "" && queue == tt.failOn {
+					return sentinel
+				}
+				return nil
+			})
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+			if int64(count) != deleted {
+				t.Errorf("count = %d but deleteFn ran %d times", count, deleted)
+			}
+		})
+	}
+}
+
+type fakeSNS struct {
+	subs         []snstypes.Subscription
+	existing     map[string]bool
+	topicErr     map[string]error
+	topicCalls   int
+	unsubscribed []string
+}
+
+func (f *fakeSNS) ListSubscriptions(_ context.Context, _ *sns.ListSubscriptionsInput, _ ...func(*sns.Options)) (*sns.ListSubscriptionsOutput, error) {
+	return &sns.ListSubscriptionsOutput{Subscriptions: f.subs}, nil
+}
+
+func (f *fakeSNS) GetTopicAttributes(_ context.Context, in *sns.GetTopicAttributesInput, _ ...func(*sns.Options)) (*sns.GetTopicAttributesOutput, error) {
+	f.topicCalls++
+	arn := aws.ToString(in.TopicArn)
+	if err, ok := f.topicErr[arn]; ok {
+		return nil, err
+	}
+	if f.existing[arn] {
+		return &sns.GetTopicAttributesOutput{}, nil
+	}
+	return nil, &smithy.GenericAPIError{Code: "NotFound", Message: "topic not found"}
+}
+
+func (f *fakeSNS) Unsubscribe(_ context.Context, in *sns.UnsubscribeInput, _ ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
+	f.unsubscribed = append(f.unsubscribed, aws.ToString(in.SubscriptionArn))
+	return &sns.UnsubscribeOutput{}, nil
+}
+
+func newSub(endpoint, topicArn, subArn string) snstypes.Subscription {
+	return snstypes.Subscription{
+		Endpoint:        aws.String(endpoint),
+		TopicArn:        aws.String(topicArn),
+		SubscriptionArn: aws.String(subArn),
+	}
+}
+
+func TestListInactiveSubscriptions(t *testing.T) {
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead2", "topic-gone", "sub-dead2"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live", "topic-live", "sub-live"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:some-other-queue", "topic-gone", "sub-other"),
+		},
+		existing: map[string]bool{"topic-live": true},
+	}
+
+	got, err := listInactiveSubscriptions(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := []string{"sub-dead", "sub-dead2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("listInactiveSubscriptions() = %v, want %v", got, want)
+	}
+	// topic-gone and topic-live are queried once each; the second lifecycled-i
+	// subscription on topic-gone is answered from the memo, and the non-lifecycled
+	// endpoint is filtered out before any topic lookup.
+	if fake.topicCalls != 2 {
+		t.Errorf("GetTopicAttributes calls = %d, want 2 (memoized per topic)", fake.topicCalls)
+	}
+}
+
+func TestDeleteInactiveSubscriptions(t *testing.T) {
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live", "topic-live", "sub-live"),
+		},
+		existing: map[string]bool{"topic-live": true},
+	}
+
+	count, err := deleteInactiveSubscriptions(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+	if !slices.Equal(fake.unsubscribed, []string{"sub-dead"}) {
+		t.Errorf("unsubscribed = %v, want [sub-dead]", fake.unsubscribed)
+	}
+}
+
+// A non-NotFound topic lookup failure must abort the listing, not silently queue
+// the subscription for deletion as if the topic were gone.
+func TestListInactiveSubscriptionsAbortsOnTopicError(t *testing.T) {
+	sentinel := &smithy.GenericAPIError{Code: "Throttling", Message: "rate exceeded"}
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-err", "sub-dead"),
+		},
+		topicErr: map[string]error{"topic-err": sentinel},
+	}
+
+	got, err := listInactiveSubscriptions(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want it to wrap %v", err, sentinel)
+	}
+	if got != nil {
+		t.Errorf("subscriptions = %v, want nil (a topic-lookup error must abort, not queue deletions)", got)
+	}
+}

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go"
 )
 
@@ -271,5 +274,89 @@ func TestListInactiveSubscriptionsAbortsOnTopicError(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("subscriptions = %v, want nil (a topic-lookup error must abort, not queue deletions)", got)
+	}
+}
+
+type fakeSQS struct {
+	pages      [][]string // queue-URL pages returned in order
+	listInputs []*sqs.ListQueuesInput
+	deleted    []string
+	deleteErr  map[string]error // per-URL DeleteQueue error
+}
+
+func (f *fakeSQS) ListQueues(_ context.Context, in *sqs.ListQueuesInput, _ ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+	f.listInputs = append(f.listInputs, in)
+	page := 0
+	if in.NextToken != nil {
+		page, _ = strconv.Atoi(aws.ToString(in.NextToken))
+	}
+	out := &sqs.ListQueuesOutput{QueueUrls: f.pages[page]}
+	// Mimic SQS: a NextToken is only handed out when MaxResults is set.
+	if in.MaxResults != nil && page+1 < len(f.pages) {
+		out.NextToken = aws.String(strconv.Itoa(page + 1))
+	}
+	return out, nil
+}
+
+func (f *fakeSQS) DeleteQueue(_ context.Context, in *sqs.DeleteQueueInput, _ ...func(*sqs.Options)) (*sqs.DeleteQueueOutput, error) {
+	url := aws.ToString(in.QueueUrl)
+	f.deleted = append(f.deleted, url)
+	if err := f.deleteErr[url]; err != nil {
+		return nil, err
+	}
+	return &sqs.DeleteQueueOutput{}, nil
+}
+
+// listQueues must follow NextToken across every page. Without MaxResults set on
+// the request, SQS caps at one page, so this also guards the MaxResults fix.
+func TestListQueuesPaginates(t *testing.T) {
+	fake := &fakeSQS{pages: [][]string{
+		{"q1", "q2"},
+		{"q3", "q4"},
+		{"q5"},
+	}}
+
+	got, err := listQueues(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	want := []string{"q1", "q2", "q3", "q4", "q5"}
+	if !slices.Equal(got, want) {
+		t.Errorf("listQueues() = %v, want %v", got, want)
+	}
+	if len(fake.listInputs) != len(fake.pages) {
+		t.Fatalf("ListQueues calls = %d, want %d (one per page)", len(fake.listInputs), len(fake.pages))
+	}
+	if aws.ToInt32(fake.listInputs[0].MaxResults) != 1000 {
+		t.Errorf("MaxResults = %d, want 1000", aws.ToInt32(fake.listInputs[0].MaxResults))
+	}
+}
+
+func TestDeleteQueue(t *testing.T) {
+	apiErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}
+	tests := []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{name: "success", err: nil},
+		{name: "already gone is success", err: &sqstypes.QueueDoesNotExist{Message: aws.String("gone")}},
+		{name: "other error propagates", err: apiErr, wantErr: apiErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeSQS{deleteErr: map[string]error{"q1": tt.err}}
+			err := deleteQueue(context.Background(), fake, "q1")
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Hardens the autoscaling listener against three failure modes surfaced while porting it to v2: a tight spin when SQS polling fails, cleanup and lifecycle-completion calls that get cut short or hang during shutdown, and a heartbeat goroutine that leaks after the handler returns. The happy path is unchanged; these only affect the error and shutdown paths.

Part of the `aws-sdk-go-v2` stack, based on `chore/ci-lint-and-race` (https://github.com/buildkite/lifecycled/pull/117). The change itself is independent of the tooling and CI branches below it.

## What changed

- SQS poll backoff: when `GetMessages` returns an error, the loop now waits `sqsErrorBackoff` (5s, with a `ctx.Done()` escape) before retrying instead of looping immediately. A persistent error (throttling, missing permissions) no longer spins the loop hot.
- Bounded shutdown contexts: queue deletion, subscription removal, and `CompleteLifecycleAction` now run on a fresh `context.WithTimeout(context.Background(), awsActionTimeout)` (30s) rather than the request context. They still run after `ctx` is cancelled during shutdown, but can no longer wedge the process on an unreachable endpoint.
- Heartbeat lifecycle: the heartbeat goroutine now selects on a context cancelled when `Handle` returns, so it stops cleanly instead of leaking. `ticker.Stop()` alone does not close the channel, so the previous `for range ticker.C` would park forever once the handler finished.

## Testing

- `TestAutoscalingListenerBacksOffOnReceiveError` asserts the poll loop backs off rather than spinning on repeated `ReceiveMessage` errors.
- `TestAutoscalingNoticeStopsHeartbeatWhenHandleReturns` asserts the heartbeat goroutine stops once `Handle` returns.
- `go build ./...`, `go vet ./...`, and `go test -race ./...` pass.
