### PR TITLE
Harden queue-cleaner concurrency, region coverage, and topic lookup

### DIFF
--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -109,7 +109,9 @@ var credentialExpiryCodes = map[string]struct{}{
 
 // fatalAWS ends the run, adding a re-auth hint when the failure is expired
 // credentials. Re-running is safe: each run re-lists from scratch and resumes
-// where the last left off.
+// where the last left off. Aborting on any AWS error (rather than skipping the
+// offending resource) is deliberate: the SDK already retries transient failures,
+// so an error reaching here is unexpected and worth stopping on.
 func fatalAWS(err error) {
 	if apiErr, expired := expiredCredential(err); expired {
 		log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", apiErr.ErrorCode(), err)

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -50,7 +50,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to resolve caller identity: %s", err)
 	}
-	if *account != "" && *account != aws.ToString(ident.Account) {
+	if !accountMatches(*account, aws.ToString(ident.Account)) {
 		log.Fatalf("Resolved account %s does not match the expected account %s", aws.ToString(ident.Account), *account)
 	}
 	log.Printf("Using account %s as %s", aws.ToString(ident.Account), aws.ToString(ident.Arn))
@@ -63,10 +63,9 @@ func main() {
 
 		if count == 0 {
 			break
-		} else {
-			log.Printf("Deleted %d subscriptions, running again as aws limits subscriptions returned to 100", count)
-			time.Sleep(time.Second * 2)
 		}
+		log.Printf("Deleted %d subscriptions, running again as aws limits subscriptions returned to 100", count)
+		time.Sleep(time.Second * 2)
 	}
 
 	for {
@@ -77,10 +76,9 @@ func main() {
 
 		if count == 0 {
 			break
-		} else {
-			log.Printf("Deleted %d queues, running again as aws limits queues returned to 1000", count)
-			time.Sleep(time.Second * 60)
 		}
+		log.Printf("Deleted %d queues, running again until a pass finds none", count)
+		time.Sleep(time.Second * 60)
 	}
 
 	log.Printf("Done! Sorry for the inconvenience!")
@@ -92,6 +90,12 @@ func callerIdentity(ctx context.Context, client *sts.Client) (*sts.GetCallerIden
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	return client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+}
+
+// accountMatches reports whether the resolved account satisfies the --account
+// guard. An empty expected means no guard was requested.
+func accountMatches(expected, resolved string) bool {
+	return expected == "" || expected == resolved
 }
 
 // credentialExpiryCodes are the AWS error codes meaning the credentials
@@ -107,61 +111,86 @@ var credentialExpiryCodes = map[string]struct{}{
 // credentials. Re-running is safe: each run re-lists from scratch and resumes
 // where the last left off.
 func fatalAWS(err error) {
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		if _, expired := credentialExpiryCodes[apiErr.ErrorCode()]; expired {
-			log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", apiErr.ErrorCode(), err)
-		}
+	if apiErr, expired := expiredCredential(err); expired {
+		log.Fatalf("Credentials expired mid-run (%s); refresh them (e.g. `aws sso login`) and run again to resume: %s", apiErr.ErrorCode(), err)
 	}
 	log.Fatal(err)
+}
+
+// expiredCredential returns the AWS API error and true when its code means the
+// credentials (temporary STS credentials or the cached SSO token) expired.
+func expiredCredential(err error) (smithy.APIError, bool) {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return nil, false
+	}
+	_, expired := credentialExpiryCodes[apiErr.ErrorCode()]
+	return apiErr, expired
 }
 
 func deleteInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *ec2.Client, parallel int) (uint64, error) {
 	queues, err := listInactiveQueues(ctx, sqsClient, ec2Client)
 	if err != nil {
-		fatalAWS(err)
+		return 0, err
 	}
+	return deleteQueues(queues, parallel, func(queue string) error {
+		return deleteQueue(ctx, sqsClient, queue)
+	})
+}
 
+// deleteQueues deletes queues using up to parallel workers. It stops at the
+// first error, returning 0 and that error; on success it returns the number
+// processed. deleteFn is expected to treat an already-deleted queue as success.
+func deleteQueues(queues []string, parallel int, deleteFn func(string) error) (uint64, error) {
+	if parallel < 1 {
+		parallel = 1
+	}
 	var wg sync.WaitGroup
 	var count uint64
-	var queuesCh = make(chan string)
-	var errCh = make(chan error)
+	queuesCh := make(chan string)
+	// Buffer to the worker count so a worker that errors after the dispatch
+	// loop has stopped reading errCh never blocks on the send (goroutine leak).
+	errCh := make(chan error, parallel)
 
-	// spawn parallel workers
+	wg.Add(parallel)
 	for i := 0; i < parallel; i++ {
-		go func(total int) {
+		go func() {
+			defer wg.Done()
 			for queue := range queuesCh {
-				atomic.AddUint64(&count, 1)
-				log.Printf("Deleting %s (%d of %d)", queue, count, total)
-				err := deleteQueue(ctx, sqsClient, queue)
-				wg.Done()
-				var notExist *sqstypes.QueueDoesNotExist
-				if errors.As(err, &notExist) {
-					continue
-				}
-				if err != nil {
+				n := atomic.AddUint64(&count, 1)
+				log.Printf("Deleting %s (%d of %d)", queue, n, len(queues))
+				if err := deleteFn(queue); err != nil {
 					errCh <- err
 					return
 				}
 			}
-		}(len(queues))
+		}()
 	}
 
-	// dispatch work to parallel workers
+	// dispatch work, stopping early once a worker reports an error
+	var err error
 	for _, queue := range queues {
 		select {
 		case queuesCh <- queue:
-			wg.Add(1)
-		case err := <-errCh:
-			close(queuesCh)
-			return 0, err
+		case err = <-errCh:
+		}
+		if err != nil {
+			break
 		}
 	}
-
-	// wait for work to finish
-	wg.Wait()
 	close(queuesCh)
+	wg.Wait()
 
+	if err == nil {
+		// Surface an error from a worker that finished after dispatch ended.
+		select {
+		case err = <-errCh:
+		default:
+		}
+	}
+	if err != nil {
+		return 0, err
+	}
 	return count, nil
 }
 
@@ -195,21 +224,26 @@ func listInstances(ctx context.Context, client *ec2.Client) ([]string, error) {
 }
 
 func listQueues(ctx context.Context, client *sqs.Client) ([]string, error) {
-	resp, err := client.ListQueues(ctx, &sqs.ListQueuesInput{
+	var urls []string
+	paginator := sqs.NewListQueuesPaginator(client, &sqs.ListQueuesInput{
 		QueueNamePrefix: aws.String(`lifecycled-`),
 	})
-	if err != nil {
-		return nil, err
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		urls = append(urls, page.QueueUrls...)
 	}
-	return resp.QueueUrls, nil
+	return urls, nil
 }
 
-var queueRegex = regexp.MustCompile(`^https://sqs\.(.+?)\.amazonaws.com/(.+?)/lifecycled-(i-.+)$`)
+var queueRegex = regexp.MustCompile(`^https://sqs\.(.+?)\.amazonaws\.com(?:\.cn)?/(.+?)/lifecycled-(i-.+)$`)
 
 func listInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *ec2.Client) ([]string, error) {
 	instances, err := listInstances(ctx, ec2Client)
 	if err != nil {
-		fatalAWS(err)
+		return nil, err
 	}
 
 	log.Printf("Found %d running instances", len(instances))
@@ -222,36 +256,56 @@ func listInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *e
 
 	queues, err := listQueues(ctx, sqsClient)
 	if err != nil {
-		fatalAWS(err)
+		return nil, err
 	}
 
-	log.Printf("Found %d queues total (aws returns max 1000)", len(queues))
+	log.Printf("Found %d lifecycled queues total", len(queues))
 
-	var inactiveQueues []string
-	for _, queue := range queues {
-		matches := queueRegex.FindStringSubmatch(queue)
-		if len(matches) != 4 {
-			continue
-		}
-		instanceID := matches[3]
-		if _, exists := instancesMap[instanceID]; !exists {
-			inactiveQueues = append(inactiveQueues, queue)
-		}
-	}
+	inactiveQueues := filterInactiveQueues(queues, instancesMap)
 
 	log.Printf("Found %d inactive queues", len(inactiveQueues))
 
 	return inactiveQueues, nil
 }
 
+// filterInactiveQueues returns the lifecycled- queue URLs whose instance id is
+// not in running. URLs that don't match the lifecycled- naming scheme are ignored.
+func filterInactiveQueues(urls []string, running map[string]struct{}) []string {
+	var inactive []string
+	for _, queue := range urls {
+		matches := queueRegex.FindStringSubmatch(queue)
+		if len(matches) != 4 {
+			continue
+		}
+		instanceID := matches[3]
+		if _, exists := running[instanceID]; !exists {
+			inactive = append(inactive, queue)
+		}
+	}
+	return inactive
+}
+
 func deleteQueue(ctx context.Context, client *sqs.Client, queueURL string) error {
 	_, err := client.DeleteQueue(ctx, &sqs.DeleteQueueInput{
 		QueueUrl: aws.String(queueURL),
 	})
+	var notExist *sqstypes.QueueDoesNotExist
+	if errors.As(err, &notExist) {
+		// Already gone; deleting a non-existent queue is success.
+		return nil
+	}
 	return err
 }
 
-func topicExists(ctx context.Context, client *sns.Client, snsTopic string) (bool, error) {
+// SNSClient is the subset of the SNS client the subscription cleanup uses, so the
+// cleanup logic can be exercised with a fake in tests.
+type SNSClient interface {
+	ListSubscriptions(context.Context, *sns.ListSubscriptionsInput, ...func(*sns.Options)) (*sns.ListSubscriptionsOutput, error)
+	GetTopicAttributes(context.Context, *sns.GetTopicAttributesInput, ...func(*sns.Options)) (*sns.GetTopicAttributesOutput, error)
+	Unsubscribe(context.Context, *sns.UnsubscribeInput, ...func(*sns.Options)) (*sns.UnsubscribeOutput, error)
+}
+
+func topicExists(ctx context.Context, client SNSClient, snsTopic string) (bool, error) {
 	_, err := client.GetTopicAttributes(ctx, &sns.GetTopicAttributesInput{
 		TopicArn: aws.String(snsTopic),
 	})
@@ -266,7 +320,7 @@ func topicExists(ctx context.Context, client *sns.Client, snsTopic string) (bool
 	return true, nil
 }
 
-func listInactiveSubscriptions(ctx context.Context, client *sns.Client) ([]string, error) {
+func listInactiveSubscriptions(ctx context.Context, client SNSClient) ([]string, error) {
 	var subs []string
 	var topics = map[string]bool{}
 	var count int
@@ -289,7 +343,14 @@ func listInactiveSubscriptions(ctx context.Context, client *sns.Client) ([]strin
 				}
 				continue
 			}
-			if exists, _ := topicExists(ctx, client, topicArn); exists {
+			exists, err := topicExists(ctx, client, topicArn)
+			if err != nil {
+				// A non-NotFound lookup failure (throttling, AccessDenied, expired
+				// creds) must not be read as "topic gone": abort rather than risk
+				// unsubscribing live subscriptions.
+				return nil, err
+			}
+			if exists {
 				topics[topicArn] = true
 			} else {
 				topics[topicArn] = false
@@ -302,7 +363,7 @@ func listInactiveSubscriptions(ctx context.Context, client *sns.Client) ([]strin
 	return subs, nil
 }
 
-func deleteInactiveSubscriptions(ctx context.Context, client *sns.Client) (int, error) {
+func deleteInactiveSubscriptions(ctx context.Context, client SNSClient) (int, error) {
 	subs, err := listInactiveSubscriptions(ctx, client)
 	if err != nil {
 		return 0, err

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -167,9 +167,18 @@ func deleteQueues(queues []string, parallel int, deleteFn func(string) error) (u
 		}()
 	}
 
-	// dispatch work, stopping early once a worker reports an error
+	// dispatch work, stopping as soon as a worker reports an error. The
+	// pre-send check keeps a buffered error from losing the select race to a
+	// ready send, which would otherwise dispatch more work after the failure.
 	var err error
 	for _, queue := range queues {
+		select {
+		case err = <-errCh:
+		default:
+		}
+		if err != nil {
+			break
+		}
 		select {
 		case queuesCh <- queue:
 		case err = <-errCh:

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -225,8 +225,11 @@ func listInstances(ctx context.Context, client *ec2.Client) ([]string, error) {
 
 func listQueues(ctx context.Context, client *sqs.Client) ([]string, error) {
 	var urls []string
+	// MaxResults is required for SQS to return a NextToken; without it the
+	// response caps at 1000 URLs and the paginator stops after one page.
 	paginator := sqs.NewListQueuesPaginator(client, &sqs.ListQueuesInput{
 		QueueNamePrefix: aws.String(`lifecycled-`),
+		MaxResults:      aws.Int32(1000),
 	})
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -234,7 +234,14 @@ func listInstances(ctx context.Context, client *ec2.Client) ([]string, error) {
 	return instances, nil
 }
 
-func listQueues(ctx context.Context, client *sqs.Client) ([]string, error) {
+// SQSClient is the subset of the SQS client the queue cleanup uses, so the
+// listing and delete logic can be exercised with a fake in tests.
+type SQSClient interface {
+	ListQueues(context.Context, *sqs.ListQueuesInput, ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error)
+	DeleteQueue(context.Context, *sqs.DeleteQueueInput, ...func(*sqs.Options)) (*sqs.DeleteQueueOutput, error)
+}
+
+func listQueues(ctx context.Context, client SQSClient) ([]string, error) {
 	var urls []string
 	// MaxResults is required for SQS to return a NextToken; without it the
 	// response caps at 1000 URLs and the paginator stops after one page.
@@ -299,7 +306,7 @@ func filterInactiveQueues(urls []string, running map[string]struct{}) []string {
 	return inactive
 }
 
-func deleteQueue(ctx context.Context, client *sqs.Client, queueURL string) error {
+func deleteQueue(ctx context.Context, client SQSClient, queueURL string) error {
 	_, err := client.DeleteQueue(ctx, &sqs.DeleteQueueInput{
 		QueueUrl: aws.String(queueURL),
 	})

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -139,6 +139,15 @@ func TestDeleteQueues(t *testing.T) {
 			failOn:   "q2",
 			wantErr:  sentinel,
 		},
+		{
+			// One queue, one worker: dispatch sends and exits before the worker
+			// reports, so the error surfaces via the post-Wait drain.
+			name:     "surfaces an error from the drain path",
+			queues:   []string{"q1"},
+			parallel: 1,
+			failOn:   "q1",
+			wantErr:  sentinel,
+		},
 	}
 
 	for _, tt := range tests {
@@ -175,6 +184,7 @@ type fakeSNS struct {
 	subs         []snstypes.Subscription
 	existing     map[string]bool
 	topicErr     map[string]error
+	unsubErr     map[string]error // per-subscription Unsubscribe error
 	topicCalls   int
 	unsubscribed []string
 }
@@ -196,7 +206,11 @@ func (f *fakeSNS) GetTopicAttributes(_ context.Context, in *sns.GetTopicAttribut
 }
 
 func (f *fakeSNS) Unsubscribe(_ context.Context, in *sns.UnsubscribeInput, _ ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
-	f.unsubscribed = append(f.unsubscribed, aws.ToString(in.SubscriptionArn))
+	arn := aws.ToString(in.SubscriptionArn)
+	if err := f.unsubErr[arn]; err != nil {
+		return nil, err
+	}
+	f.unsubscribed = append(f.unsubscribed, arn)
 	return &sns.UnsubscribeOutput{}, nil
 }
 
@@ -214,6 +228,7 @@ func TestListInactiveSubscriptions(t *testing.T) {
 			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
 			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead2", "topic-gone", "sub-dead2"),
 			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live", "topic-live", "sub-live"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live2", "topic-live", "sub-live2"),
 			newSub("arn:aws:sqs:us-east-1:123456789012:some-other-queue", "topic-gone", "sub-other"),
 		},
 		existing: map[string]bool{"topic-live": true},
@@ -228,9 +243,9 @@ func TestListInactiveSubscriptions(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Errorf("listInactiveSubscriptions() = %v, want %v", got, want)
 	}
-	// topic-gone and topic-live are queried once each; the second lifecycled-i
-	// subscription on topic-gone is answered from the memo, and the non-lifecycled
-	// endpoint is filtered out before any topic lookup.
+	// topic-gone and topic-live are queried once each; the second subscription on
+	// each topic is answered from the memo (the dead one is queued, the live one
+	// is skipped), and the non-lifecycled endpoint is filtered out before any lookup.
 	if fake.topicCalls != 2 {
 		t.Errorf("GetTopicAttributes calls = %d, want 2 (memoized per topic)", fake.topicCalls)
 	}
@@ -254,6 +269,25 @@ func TestDeleteInactiveSubscriptions(t *testing.T) {
 	}
 	if !slices.Equal(fake.unsubscribed, []string{"sub-dead"}) {
 		t.Errorf("unsubscribed = %v, want [sub-dead]", fake.unsubscribed)
+	}
+}
+
+func TestDeleteInactiveSubscriptionsUnsubscribeError(t *testing.T) {
+	boom := errors.New("unsubscribe failed")
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead2", "topic-gone", "sub-dead2"),
+		},
+		unsubErr: map[string]error{"sub-dead": boom},
+	}
+
+	count, err := deleteInactiveSubscriptions(context.Background(), fake)
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want %v", err, boom)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0 (aborts on the first unsubscribe failure)", count)
 	}
 }
 

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/aws/smithy-go"
+)
+
+func TestFilterInactiveQueues(t *testing.T) {
+	const (
+		dead    = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-dead"
+		running = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-running"
+		other   = "https://sqs.us-east-1.amazonaws.com/123456789012/some-other-queue"
+		chinaCN = "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/lifecycled-i-dead"
+	)
+	runningSet := map[string]struct{}{"i-running": {}}
+
+	tests := []struct {
+		name string
+		urls []string
+		want []string
+	}{
+		{name: "empty input", urls: nil, want: nil},
+		{name: "keeps queue for terminated instance", urls: []string{dead}, want: []string{dead}},
+		{name: "skips queue for running instance", urls: []string{running}, want: nil},
+		{name: "ignores non-lifecycled queue", urls: []string{other}, want: nil},
+		{name: "matches china partition url", urls: []string{chinaCN}, want: []string{chinaCN}},
+		{name: "mixed", urls: []string{dead, running, other}, want: []string{dead}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterInactiveQueues(tt.urls, runningSet); !slices.Equal(got, tt.want) {
+				t.Errorf("filterInactiveQueues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAccountMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		resolved string
+		want     bool
+	}{
+		{name: "no guard requested", expected: "", resolved: "123456789012", want: true},
+		{name: "match", expected: "123456789012", resolved: "123456789012", want: true},
+		{name: "mismatch", expected: "123456789012", resolved: "999999999999", want: false},
+		{name: "guard set but account unresolved aborts", expected: "123456789012", resolved: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := accountMatches(tt.expected, tt.resolved); got != tt.want {
+				t.Errorf("accountMatches(%q, %q) = %v, want %v", tt.expected, tt.resolved, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpiredCredential(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "non-API error", err: errors.New("boom"), want: false},
+		{name: "other API error", err: &smithy.GenericAPIError{Code: "AccessDenied"}, want: false},
+		{name: "ExpiredToken", err: &smithy.GenericAPIError{Code: "ExpiredToken"}, want: true},
+		{name: "ExpiredTokenException", err: &smithy.GenericAPIError{Code: "ExpiredTokenException"}, want: true},
+		{name: "RequestExpired", err: &smithy.GenericAPIError{Code: "RequestExpired"}, want: true},
+		{name: "SSOProviderInvalidToken", err: &smithy.GenericAPIError{Code: "SSOProviderInvalidToken"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, got := expiredCredential(tt.err); got != tt.want {
+				t.Errorf("expiredCredential() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteQueues(t *testing.T) {
+	sentinel := errors.New("delete failed")
+	tests := []struct {
+		name      string
+		queues    []string
+		parallel  int
+		failOn    string
+		wantCount uint64
+		wantErr   error
+	}{
+		{
+			name:      "deletes all queues",
+			queues:    []string{"q1", "q2", "q3", "q4", "q5"},
+			parallel:  3,
+			wantCount: 5,
+		},
+		{
+			name:     "no queues",
+			queues:   nil,
+			parallel: 3,
+		},
+		{
+			name:      "fewer queues than workers",
+			queues:    []string{"q1", "q2"},
+			parallel:  10,
+			wantCount: 2,
+		},
+		{
+			name:      "single worker",
+			queues:    []string{"q1", "q2", "q3"},
+			parallel:  1,
+			wantCount: 3,
+		},
+		{
+			name:      "non-positive parallel is clamped to one worker",
+			queues:    []string{"q1", "q2", "q3"},
+			parallel:  0,
+			wantCount: 3,
+		},
+		{
+			name:     "surfaces a delete error",
+			queues:   []string{"q1", "q2", "q3"},
+			parallel: 2,
+			failOn:   "q2",
+			wantErr:  sentinel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleted int64
+			count, err := deleteQueues(tt.queues, tt.parallel, func(queue string) error {
+				atomic.AddInt64(&deleted, 1)
+				if tt.failOn != "" && queue == tt.failOn {
+					return sentinel
+				}
+				return nil
+			})
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+			if int64(count) != deleted {
+				t.Errorf("count = %d but deleteFn ran %d times", count, deleted)
+			}
+		})
+	}
+}
+
+type fakeSNS struct {
+	subs         []snstypes.Subscription
+	existing     map[string]bool
+	topicErr     map[string]error
+	topicCalls   int
+	unsubscribed []string
+}
+
+func (f *fakeSNS) ListSubscriptions(_ context.Context, _ *sns.ListSubscriptionsInput, _ ...func(*sns.Options)) (*sns.ListSubscriptionsOutput, error) {
+	return &sns.ListSubscriptionsOutput{Subscriptions: f.subs}, nil
+}
+
+func (f *fakeSNS) GetTopicAttributes(_ context.Context, in *sns.GetTopicAttributesInput, _ ...func(*sns.Options)) (*sns.GetTopicAttributesOutput, error) {
+	f.topicCalls++
+	arn := aws.ToString(in.TopicArn)
+	if err, ok := f.topicErr[arn]; ok {
+		return nil, err
+	}
+	if f.existing[arn] {
+		return &sns.GetTopicAttributesOutput{}, nil
+	}
+	return nil, &smithy.GenericAPIError{Code: "NotFound", Message: "topic not found"}
+}
+
+func (f *fakeSNS) Unsubscribe(_ context.Context, in *sns.UnsubscribeInput, _ ...func(*sns.Options)) (*sns.UnsubscribeOutput, error) {
+	f.unsubscribed = append(f.unsubscribed, aws.ToString(in.SubscriptionArn))
+	return &sns.UnsubscribeOutput{}, nil
+}
+
+func newSub(endpoint, topicArn, subArn string) snstypes.Subscription {
+	return snstypes.Subscription{
+		Endpoint:        aws.String(endpoint),
+		TopicArn:        aws.String(topicArn),
+		SubscriptionArn: aws.String(subArn),
+	}
+}
+
+func TestListInactiveSubscriptions(t *testing.T) {
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead2", "topic-gone", "sub-dead2"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live", "topic-live", "sub-live"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:some-other-queue", "topic-gone", "sub-other"),
+		},
+		existing: map[string]bool{"topic-live": true},
+	}
+
+	got, err := listInactiveSubscriptions(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := []string{"sub-dead", "sub-dead2"}
+	if !slices.Equal(got, want) {
+		t.Errorf("listInactiveSubscriptions() = %v, want %v", got, want)
+	}
+	// topic-gone and topic-live are queried once each; the second lifecycled-i
+	// subscription on topic-gone is answered from the memo, and the non-lifecycled
+	// endpoint is filtered out before any topic lookup.
+	if fake.topicCalls != 2 {
+		t.Errorf("GetTopicAttributes calls = %d, want 2 (memoized per topic)", fake.topicCalls)
+	}
+}
+
+func TestDeleteInactiveSubscriptions(t *testing.T) {
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-gone", "sub-dead"),
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-live", "topic-live", "sub-live"),
+		},
+		existing: map[string]bool{"topic-live": true},
+	}
+
+	count, err := deleteInactiveSubscriptions(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+	if !slices.Equal(fake.unsubscribed, []string{"sub-dead"}) {
+		t.Errorf("unsubscribed = %v, want [sub-dead]", fake.unsubscribed)
+	}
+}
+
+// A non-NotFound topic lookup failure must abort the listing, not silently queue
+// the subscription for deletion as if the topic were gone.
+func TestListInactiveSubscriptionsAbortsOnTopicError(t *testing.T) {
+	sentinel := &smithy.GenericAPIError{Code: "Throttling", Message: "rate exceeded"}
+	fake := &fakeSNS{
+		subs: []snstypes.Subscription{
+			newSub("arn:aws:sqs:us-east-1:123456789012:lifecycled-i-dead", "topic-err", "sub-dead"),
+		},
+		topicErr: map[string]error{"topic-err": sentinel},
+	}
+
+	got, err := listInactiveSubscriptions(context.Background(), fake)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want it to wrap %v", err, sentinel)
+	}
+	if got != nil {
+		t.Errorf("subscriptions = %v, want nil (a topic-lookup error must abort, not queue deletions)", got)
+	}
+}

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strconv"
 	"sync/atomic"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/aws/smithy-go"
 )
 
@@ -271,5 +274,89 @@ func TestListInactiveSubscriptionsAbortsOnTopicError(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("subscriptions = %v, want nil (a topic-lookup error must abort, not queue deletions)", got)
+	}
+}
+
+type fakeSQS struct {
+	pages      [][]string // queue-URL pages returned in order
+	listInputs []*sqs.ListQueuesInput
+	deleted    []string
+	deleteErr  map[string]error // per-URL DeleteQueue error
+}
+
+func (f *fakeSQS) ListQueues(_ context.Context, in *sqs.ListQueuesInput, _ ...func(*sqs.Options)) (*sqs.ListQueuesOutput, error) {
+	f.listInputs = append(f.listInputs, in)
+	page := 0
+	if in.NextToken != nil {
+		page, _ = strconv.Atoi(aws.ToString(in.NextToken))
+	}
+	out := &sqs.ListQueuesOutput{QueueUrls: f.pages[page]}
+	// Mimic SQS: a NextToken is only handed out when MaxResults is set.
+	if in.MaxResults != nil && page+1 < len(f.pages) {
+		out.NextToken = aws.String(strconv.Itoa(page + 1))
+	}
+	return out, nil
+}
+
+func (f *fakeSQS) DeleteQueue(_ context.Context, in *sqs.DeleteQueueInput, _ ...func(*sqs.Options)) (*sqs.DeleteQueueOutput, error) {
+	url := aws.ToString(in.QueueUrl)
+	f.deleted = append(f.deleted, url)
+	if err := f.deleteErr[url]; err != nil {
+		return nil, err
+	}
+	return &sqs.DeleteQueueOutput{}, nil
+}
+
+// listQueues must follow NextToken across every page. Without MaxResults set on
+// the request, SQS caps at one page, so this also guards the MaxResults fix.
+func TestListQueuesPaginates(t *testing.T) {
+	fake := &fakeSQS{pages: [][]string{
+		{"q1", "q2"},
+		{"q3", "q4"},
+		{"q5"},
+	}}
+
+	got, err := listQueues(context.Background(), fake)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	want := []string{"q1", "q2", "q3", "q4", "q5"}
+	if !slices.Equal(got, want) {
+		t.Errorf("listQueues() = %v, want %v", got, want)
+	}
+	if len(fake.listInputs) != len(fake.pages) {
+		t.Fatalf("ListQueues calls = %d, want %d (one per page)", len(fake.listInputs), len(fake.pages))
+	}
+	if aws.ToInt32(fake.listInputs[0].MaxResults) != 1000 {
+		t.Errorf("MaxResults = %d, want 1000", aws.ToInt32(fake.listInputs[0].MaxResults))
+	}
+}
+
+func TestDeleteQueue(t *testing.T) {
+	apiErr := &smithy.GenericAPIError{Code: "AccessDenied", Message: "denied"}
+	tests := []struct {
+		name    string
+		err     error
+		wantErr error
+	}{
+		{name: "success", err: nil},
+		{name: "already gone is success", err: &sqstypes.QueueDoesNotExist{Message: aws.String("gone")}},
+		{name: "other error propagates", err: apiErr, wantErr: apiErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeSQS{deleteErr: map[string]error{"q1": tt.err}}
+			err := deleteQueue(context.Background(), fake, "q1")
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Hardens the `lifecycled-queue-cleaner` tool across four areas surfaced during the v2 port: the delete worker pool (a goroutine leak and a best-effort stop-on-error that did not actually stop), region coverage (queue URLs outside the standard AWS partition), SNS topic lookups (a transient error silently treated as a missing topic), and queue listing (a paginator that only ever read one page). Also extracts pure helpers and adds `SQSClient`/`SNSClient` interfaces so the logic is unit-testable.

Part of the `aws-sdk-go-v2` stack, based on `chore/listener-hardening` (https://github.com/buildkite/lifecycled/pull/118). It touches only the queue-cleaner tool and is independent of the branches below it.

## What changed

Concurrency

- The delete worker pool is rewritten and extracted as `deleteQueues`. `errCh` is buffered to the worker count, so a worker that errors after the dispatch loop has stopped reading no longer blocks forever on the send (the previous goroutine leak). Workers start with `wg.Add(parallel)` up front and `defer wg.Done()`, and a late error is drained after the wait.
- Dispatch now stops promptly on the first error. A non-blocking `errCh` check before each send keeps a buffered error from losing the `select` race to a ready send, which previously let the loop keep dispatching after a worker had already failed. `parallel < 1` is clamped to 1.

Region coverage

- The queue-URL regex escapes the literal dot in `amazonaws.com` and matches the China partition (`amazonaws.com.cn`), so China-region queues are recognized and cleaned instead of skipped.

Topic lookup

- Subscription cleanup aborts on a non-`NotFound` `GetTopicAttributes` error (throttling, AccessDenied, expired credentials) instead of treating it as "topic gone." A transient lookup failure could previously lead to unsubscribing live instances.

Listing and structure

- `listQueues` paginates with `NewListQueuesPaginator` and sets `MaxResults: aws.Int32(1000)`. SQS only returns a `NextToken` when `MaxResults` is set, so without it the listing capped at a single page of 1000 URLs; with it the paginator now spans every page and large accounts are fully covered.
- `deleteQueue` treats `QueueDoesNotExist` as success, so an already-deleted queue is not an error.
- AWS errors propagate up to the single `fatalAWS` call site in `main` rather than being raised deep in the call tree. Aborting on any AWS error (rather than skipping the offending resource) is deliberate and documented: the SDK already retries transient failures, and each re-run re-lists from scratch and resumes where the last left off.
- Pure helpers are extracted for testing (`accountMatches`, `expiredCredential`, `filterInactiveQueues`, `deleteQueues`), along with `SQSClient` and `SNSClient` interfaces so the listing, delete, and subscription-cleanup logic can run against fakes.

## Testing

Unit tests in `main_test.go`:

- `TestFilterInactiveQueues` (URL matching, including the China partition)
- `TestAccountMatches` and `TestExpiredCredential`
- `TestDeleteQueues` (worker pool, including the error path and the post-wait drain path)
- `TestListQueuesPaginates` (the paginator follows `NextToken` across pages; the fake only returns a token when `MaxResults` is set, so it guards the listing fix)
- `TestDeleteQueue` (`QueueDoesNotExist` is success, other errors propagate)
- `TestListInactiveSubscriptions` and `TestDeleteInactiveSubscriptions` (including the per-topic memo)
- `TestListInactiveSubscriptionsAbortsOnTopicError` (the topic-lookup abort)
- `TestDeleteInactiveSubscriptionsUnsubscribeError` (abort and partial count on an `Unsubscribe` failure)

`go build ./...`, `go vet ./...`, and `go test -race ./...` pass.
