### PR TITLE
 Validate daemon config and propagate drain failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Lifecycled runs as a daemon on your EC2 instances and:
    - Sends periodic heartbeats to AWS to extend the timeout
    - Completes the lifecycle action when the handler finishes
 
-   AutoScaling notices are handled at most once: the SQS message is deleted on receipt, before the handler runs. If lifecycled is killed mid-drain it does not resume on restart; the instance waits out the hook's `HeartbeatTimeout`, then the ASG applies its default result, so size that timeout accordingly. (Spot notices differ: they are re-read from instance metadata each poll, so a restarted daemon re-runs the handler.)
+   AutoScaling notices are handled at most once: the SQS message is deleted on receipt, before the handler runs. If lifecycled crashes or is hard-killed (SIGKILL) mid-drain it does not resume on restart; the instance waits out the hook's `HeartbeatTimeout`, then the ASG applies its default result, so size that timeout accordingly. A graceful SIGINT/SIGTERM instead cancels the handler but still completes the lifecycle action, so the instance proceeds without waiting. (Spot notices differ: they are re-read from instance metadata each poll, so a restarted daemon re-runs the handler.)
 
 2. **For Spot Terminations**: Polls the EC2 instance metadata service for spot termination notices. When detected:
    - Executes your handler script

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Lifecycled runs as a daemon on your EC2 instances and:
    - Sends periodic heartbeats to AWS to extend the timeout
    - Completes the lifecycle action when the handler finishes
 
+   AutoScaling notices are handled at most once: the SQS message is deleted on receipt, before the handler runs. If lifecycled is killed mid-drain it does not resume on restart; the instance waits out the hook's `HeartbeatTimeout`, then the ASG applies its default result, so size that timeout accordingly. (Spot notices differ: they are re-read from instance metadata each poll, so a restarted daemon re-runs the handler.)
+
 2. **For Spot Terminations**: Polls the EC2 instance metadata service for spot termination notices. When detected:
    - Executes your handler script
    - Allows graceful shutdown before AWS terminates the instance

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Lifecycled is configured via command-line flags or environment variables (with `
 | `--cloudwatch-stream` | `LIFECYCLED_CLOUDWATCH_STREAM` | Instance ID | CloudWatch Logs stream name |
 | `--tags` | `LIFECYCLED_TAGS` | - | Comma-separated tags for SQS queues (e.g., `Team=platform,Environment=prod`) |
 | `--spot-listener-interval` | `LIFECYCLED_SPOT_LISTENER_INTERVAL` | `5s` | Interval to check for spot termination notices |
-| `--autoscaling-heartbeat-interval` | `LIFECYCLED_AUTOSCALING_HEARTBEAT_INTERVAL` | `10s` | Interval to send lifecycle heartbeats to AWS |
+| `--autoscaling-heartbeat-interval` | `LIFECYCLED_AUTOSCALING_HEARTBEAT_INTERVAL` | `10s` | Interval to send lifecycle heartbeats to AWS; keep shorter than the hook's `HeartbeatTimeout` |
 
 ### AWS Configuration
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ kubectl drain "${NODE_NAME}" \
   --grace-period=300
 ```
 
+## Exit codes and restarts
+
+Lifecycled exits 0 when the handler completes successfully, and also when a drain is cut short by lifecycled's own SIGINT/SIGTERM: a graceful self-shutdown is not a failure. It exits non-zero only when the handler itself returns non-zero, for both autoscaling and spot terminations.
+
+The shipped [systemd unit](init/systemd/lifecycled.unit) sets `Restart=on-failure` with `RestartSec=30s`, so a failed handler restarts the daemon. A restarted autoscaling drain does not re-run the handler: the notice is handled at most once (as described above), and the lifecycle action is completed regardless of the handler's result. A restarted spot drain does re-run the handler, because the notice is re-read from instance metadata; with the 30s `RestartSec` and the roughly two-minute spot warning that retries a few times before the instance is reclaimed, which recovers a transient failure but loops on one that fails deterministically. Set `Restart=no` if you would rather a handler run exactly once.
+
 ## IAM Permissions
 
 Lifecycled requires specific IAM permissions to function properly.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Lifecycled runs as a daemon on your EC2 instances and:
    - Sends periodic heartbeats to AWS to extend the timeout
    - Completes the lifecycle action when the handler finishes
 
-   AutoScaling notices are handled at most once: the SQS message is deleted on receipt, before the handler runs. If lifecycled crashes or is hard-killed (SIGKILL) mid-drain it does not resume on restart; the instance waits out the hook's `HeartbeatTimeout`, then the ASG applies its default result, so size that timeout accordingly. A graceful SIGINT/SIGTERM instead cancels the handler but still completes the lifecycle action, so the instance proceeds without waiting. (Spot notices differ: they are re-read from instance metadata each poll, so a restarted daemon re-runs the handler.)
+   lifecycled deletes each AutoScaling SQS message on receipt, before the handler runs, so after a successful delete the drain isn't replayed on restart. That delete is best-effort: if it fails (or the queue isn't torn down on shutdown), SQS may redeliver the message and re-run the handler. If lifecycled crashes or is hard-killed (SIGKILL) mid-drain it does not resume on restart; the instance waits out the hook's `HeartbeatTimeout`, then the ASG applies its default result, so size that timeout accordingly. A graceful SIGINT/SIGTERM instead cancels the handler but still completes the lifecycle action, so the instance proceeds without waiting. (Spot notices differ: they are re-read from instance metadata each poll, so a restarted daemon re-runs the handler.)
 
 2. **For Spot Terminations**: Polls the EC2 instance metadata service for spot termination notices. When detected:
    - Executes your handler script
@@ -242,9 +242,9 @@ kubectl drain "${NODE_NAME}" \
 
 ## Exit codes and restarts
 
-Lifecycled exits 0 when the handler completes successfully, and also when a drain is cut short by lifecycled's own SIGINT/SIGTERM: a graceful self-shutdown is not a failure. It exits non-zero only when the handler itself returns non-zero, for both autoscaling and spot terminations.
+Lifecycled exits 0 when the handler completes successfully, and also when a drain is cut short by lifecycled's own SIGINT/SIGTERM: a graceful self-shutdown is not a failure. Once a drain has started, it exits non-zero only when the handler itself returns non-zero, for both autoscaling and spot terminations. It also exits non-zero on any fatal startup error before a drain begins, such as invalid config, AWS/IMDS setup failures, or a listener that fails to start.
 
-The shipped [systemd unit](init/systemd/lifecycled.unit) sets `Restart=on-failure` with `RestartSec=30s`, so a failed handler restarts the daemon. A restarted autoscaling drain does not re-run the handler: the notice is handled at most once (as described above), and the lifecycle action is completed regardless of the handler's result. A restarted spot drain does re-run the handler, because the notice is re-read from instance metadata; with the 30s `RestartSec` and the roughly two-minute spot warning that retries a few times before the instance is reclaimed, which recovers a transient failure but loops on one that fails deterministically. Set `Restart=no` if you would rather a handler run exactly once.
+The shipped [systemd unit](init/systemd/lifecycled.unit) sets `Restart=on-failure` with `RestartSec=30s`, so a failed handler restarts the daemon. A restarted autoscaling drain normally does not re-run the handler: the SQS message is deleted on receipt (best-effort, as described above), and the lifecycle action is completed regardless of the handler's result. A restarted spot drain does re-run the handler, because the notice is re-read from instance metadata; with the 30s `RestartSec` and the roughly two-minute spot warning that retries a few times before the instance is reclaimed, which recovers a transient failure but loops on one that fails deterministically. Set `Restart=no` if you would rather a handler run exactly once.
 
 ## IAM Permissions
 

--- a/autoscaling.go
+++ b/autoscaling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -237,5 +238,12 @@ func (n *autoscalingTerminationNotice) Handle(ctx context.Context, handler Handl
 		}
 	}()
 
-	return handler.Execute(ctx, n.message.Transition, n.message.InstanceID)
+	// Snapshot cancellation here, before the deferred CompleteLifecycleAction runs
+	// on a fresh context for up to awsActionTimeout: a SIGTERM landing during that
+	// cleanup must not relabel a genuine handler failure as an interrupt.
+	err := handler.Execute(ctx, n.message.Transition, n.message.InstanceID)
+	if err != nil && ctx.Err() != nil {
+		return fmt.Errorf("%w: %w", ErrDrainInterrupted, err)
+	}
+	return err
 }

--- a/autoscaling_test.go
+++ b/autoscaling_test.go
@@ -299,6 +299,55 @@ func TestAutoscalingNoticeCompletesOnCancellation(t *testing.T) {
 	}
 }
 
+// failingHandler returns a genuine error immediately, modelling a drain script
+// that fails on its own merits while the context is still live.
+type failingHandler struct{ err error }
+
+func (h failingHandler) Execute(context.Context, ...string) error { return h.err }
+
+// cancelOnCompleteASGClient cancels the daemon context from inside
+// CompleteLifecycleAction, modelling a SIGTERM that lands during the detached
+// cleanup that runs after the handler has already failed.
+type cancelOnCompleteASGClient struct{ cancel context.CancelFunc }
+
+func (c cancelOnCompleteASGClient) CompleteLifecycleAction(context.Context, *autoscaling.CompleteLifecycleActionInput, ...func(*autoscaling.Options)) (*autoscaling.CompleteLifecycleActionOutput, error) {
+	c.cancel()
+	return &autoscaling.CompleteLifecycleActionOutput{}, nil
+}
+
+func (cancelOnCompleteASGClient) RecordLifecycleActionHeartbeat(context.Context, *autoscaling.RecordLifecycleActionHeartbeatInput, ...func(*autoscaling.Options)) (*autoscaling.RecordLifecycleActionHeartbeatOutput, error) {
+	return &autoscaling.RecordLifecycleActionHeartbeatOutput{}, nil
+}
+
+// A handler that fails on its own merits must stay a genuine failure even when a
+// SIGTERM cancels the context during the detached CompleteLifecycleAction that
+// runs after the handler returns. Handle snapshots cancellation when the handler
+// returns, so the up-to-awsActionTimeout cleanup window can't relabel a real
+// failure as an interrupt and exit 0.
+func TestAutoscalingNoticeFailureSurvivesCancellationDuringCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handlerErr := errors.New("drain failed")
+	notice := &autoscalingTerminationNotice{
+		noticeType:        "autoscaling",
+		message:           &Message{GroupName: "g", HookName: "h", InstanceID: "i", ActionToken: "t"},
+		autoscaling:       cancelOnCompleteASGClient{cancel: cancel},
+		heartbeatInterval: time.Hour,
+	}
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	err := notice.Handle(ctx, failingHandler{err: handlerErr}, logrus.NewEntry(logger))
+	if !errors.Is(err, handlerErr) {
+		t.Fatalf("Handle returned %v, want the handler error", err)
+	}
+	if errors.Is(err, ErrDrainInterrupted) {
+		t.Error("handler failure relabelled as interrupt after cancellation during cleanup; the process would exit 0")
+	}
+}
+
 // countingASGClient counts heartbeats so a test can assert the heartbeat
 // goroutine stops once Handle returns.
 type countingASGClient struct {

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -75,7 +75,7 @@ func main() {
 		Default("5s").
 		DurationVar(&spotListenerInterval)
 
-	app.Flag("autoscaling-heartbeat-interval", "Interval to send AWS Lifecycle Heartbeat Actions").
+	app.Flag("autoscaling-heartbeat-interval", "Interval to send AWS Lifecycle Heartbeat Actions; keep shorter than the hook's HeartbeatTimeout").
 		Default("10s").
 		DurationVar(&autoscalingHeartbeatInterval)
 

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -201,14 +201,45 @@ func main() {
 			start := time.Now()
 			err = notice.Handle(ctx, handler, log)
 			log = log.WithField("duration", time.Since(start).String())
-			if err != nil {
+			switch classifyDrain(err, ctx.Err()) {
+			case drainInterrupted:
+				// Our own SIGINT/SIGTERM cancelled the drain; the lifecycle action
+				// still completes on a fresh context, so this is a clean shutdown.
+				log.WithError(err).Warn("Handler interrupted by shutdown")
+			case drainFailed:
 				log.WithError(err).Error("Failed to execute handler")
 				return err
+			case drainSucceeded:
+				log.Info("Handler finished successfully")
 			}
-			log.Info("Handler finished successfully")
 		}
 		return nil
 	})
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+}
+
+// drainOutcome classifies how a termination handler finished, which decides both
+// what we log and whether the process exits non-zero.
+type drainOutcome int
+
+const (
+	drainSucceeded drainOutcome = iota
+	drainFailed
+	drainInterrupted
+)
+
+// classifyDrain interprets the handler's result against the daemon context. A
+// handler error is a genuine failure only when our own context wasn't cancelled:
+// a SIGINT/SIGTERM that cancels the drain is a clean shutdown, not a failure, so
+// it must not make the process exit non-zero.
+func classifyDrain(handlerErr, ctxErr error) drainOutcome {
+	switch {
+	case handlerErr == nil:
+		return drainSucceeded
+	case ctxErr != nil:
+		return drainInterrupted
+	default:
+		return drainFailed
+	}
 }

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -194,13 +194,14 @@ func main() {
 			// The handler runs on the signal-cancellable ctx, so a SIGINT/SIGTERM
 			// mid-handle intentionally cancels the drain script; the autoscaling notice
 			// still releases the ASG hook via CompleteLifecycleAction on a fresh context.
-			start, err := time.Now(), notice.Handle(ctx, handler, log)
+			start := time.Now()
+			err = notice.Handle(ctx, handler, log)
 			log = log.WithField("duration", time.Since(start).String())
 			if err != nil {
 				log.WithError(err).Error("Failed to execute handler")
+				return err
 			}
 			log.Info("Handler finished successfully")
-
 		}
 		return nil
 	})

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -170,14 +170,18 @@ func main() {
 		}()
 
 		handler := lifecycled.NewFileHandler(handler)
-		daemon := lifecycled.New(&lifecycled.Config{
+		daemonConfig := &lifecycled.Config{
 			InstanceID:                   instanceID,
 			Tags:                         tags,
 			SNSTopic:                     snsTopic,
 			SpotListener:                 !disableSpotListener,
 			SpotListenerInterval:         spotListenerInterval,
 			AutoscalingHeartbeatInterval: autoscalingHeartbeatInterval,
-		}, cfg, logger)
+		}
+		if err := daemonConfig.Validate(); err != nil {
+			logger.WithError(err).Fatal("Invalid configuration")
+		}
+		daemon := lifecycled.New(daemonConfig, cfg, logger)
 
 		notice, err := daemon.Start(ctx)
 		if err != nil {

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -91,6 +91,20 @@ func main() {
 			logger.SetLevel(logrus.DebugLevel)
 		}
 
+		// Validate the flags before touching AWS so a misconfiguration surfaces
+		// immediately rather than behind a region or IMDS error. InstanceID is
+		// filled in below once resolved.
+		daemonConfig := &lifecycled.Config{
+			Tags:                         tags,
+			SNSTopic:                     snsTopic,
+			SpotListener:                 !disableSpotListener,
+			SpotListenerInterval:         spotListenerInterval,
+			AutoscalingHeartbeatInterval: autoscalingHeartbeatInterval,
+		}
+		if err := daemonConfig.Validate(); err != nil {
+			logger.WithError(err).Fatal("Invalid configuration")
+		}
+
 		// Cancelled on SIGINT/SIGTERM by the signal handler below.
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -170,17 +184,7 @@ func main() {
 		}()
 
 		handler := lifecycled.NewFileHandler(handler)
-		daemonConfig := &lifecycled.Config{
-			InstanceID:                   instanceID,
-			Tags:                         tags,
-			SNSTopic:                     snsTopic,
-			SpotListener:                 !disableSpotListener,
-			SpotListenerInterval:         spotListenerInterval,
-			AutoscalingHeartbeatInterval: autoscalingHeartbeatInterval,
-		}
-		if err := daemonConfig.Validate(); err != nil {
-			logger.WithError(err).Fatal("Invalid configuration")
-		}
+		daemonConfig.InstanceID = instanceID
 		daemon := lifecycled.New(daemonConfig, cfg, logger)
 
 		notice, err := daemon.Start(ctx)

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"os/signal"
@@ -213,7 +214,7 @@ func handleNotice(ctx context.Context, notice lifecycled.TerminationNotice, hand
 	start := time.Now()
 	err := notice.Handle(ctx, handler, log)
 	log = log.WithField("duration", time.Since(start).String())
-	switch classifyDrain(err, ctx.Err()) {
+	switch classifyDrain(err) {
 	case drainSucceeded:
 		log.Info("Handler finished successfully")
 	case drainFailed:
@@ -235,19 +236,16 @@ const (
 	drainInterrupted
 )
 
-// classifyDrain interprets the handler's result against the daemon context. A
-// handler error is a genuine failure only when our own context wasn't cancelled:
-// a SIGINT/SIGTERM that cancels the drain is a clean shutdown, not a failure, so
-// it must not make the process exit non-zero.
-func classifyDrain(handlerErr, ctxErr error) drainOutcome {
+// classifyDrain interprets the handler's result. A handler error is a genuine
+// failure unless Handle marked it ErrDrainInterrupted, meaning our own
+// SIGINT/SIGTERM cancelled the drain: a clean shutdown, not a failure, so it must
+// not make the process exit non-zero. Handle captures that cause when the handler
+// returns, so detached cleanup (e.g. CompleteLifecycleAction) can't relabel it.
+func classifyDrain(handlerErr error) drainOutcome {
 	switch {
 	case handlerErr == nil:
 		return drainSucceeded
-	case ctxErr != nil:
-		// Deliberate trade-off: a handler that failed on its own merits at the
-		// same instant a SIGINT/SIGTERM arrived is reported as an interrupt, not a
-		// failure. exec.CommandContext's kill error is indistinguishable from the
-		// child's own non-zero exit, and the race window is narrow.
+	case errors.Is(handlerErr, lifecycled.ErrDrainInterrupted):
 		return drainInterrupted
 	default:
 		return drainFailed

--- a/cmd/lifecycled/main.go
+++ b/cmd/lifecycled/main.go
@@ -193,30 +193,36 @@ func main() {
 		}
 		if notice != nil {
 			log := logger.WithFields(logrus.Fields{"instanceId": instanceID, "notice": notice.Type()})
-			log.Info("Executing handler")
-
-			// The handler runs on the signal-cancellable ctx, so a SIGINT/SIGTERM
-			// mid-handle intentionally cancels the drain script; the autoscaling notice
-			// still releases the ASG hook via CompleteLifecycleAction on a fresh context.
-			start := time.Now()
-			err = notice.Handle(ctx, handler, log)
-			log = log.WithField("duration", time.Since(start).String())
-			switch classifyDrain(err, ctx.Err()) {
-			case drainInterrupted:
-				// Our own SIGINT/SIGTERM cancelled the drain; the lifecycle action
-				// still completes on a fresh context, so this is a clean shutdown.
-				log.WithError(err).Warn("Handler interrupted by shutdown")
-			case drainFailed:
-				log.WithError(err).Error("Failed to execute handler")
-				return err
-			case drainSucceeded:
-				log.Info("Handler finished successfully")
-			}
+			return handleNotice(ctx, notice, handler, log)
 		}
 		return nil
 	})
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+}
+
+// handleNotice runs the termination handler and maps its outcome to a process
+// exit: a genuine handler failure is returned so the process exits non-zero,
+// while a success or a drain cancelled by our own shutdown returns nil.
+func handleNotice(ctx context.Context, notice lifecycled.TerminationNotice, handler lifecycled.Handler, log *logrus.Entry) error {
+	log.Info("Executing handler")
+
+	// The handler runs on the signal-cancellable ctx, so a SIGINT/SIGTERM
+	// mid-handle intentionally cancels the drain script; the autoscaling notice
+	// still releases the ASG hook via CompleteLifecycleAction on a fresh context.
+	start := time.Now()
+	err := notice.Handle(ctx, handler, log)
+	log = log.WithField("duration", time.Since(start).String())
+	switch classifyDrain(err, ctx.Err()) {
+	case drainSucceeded:
+		log.Info("Handler finished successfully")
+	case drainFailed:
+		log.WithError(err).Error("Failed to execute handler")
+		return err
+	case drainInterrupted:
+		log.WithError(err).Warn("Handler interrupted by shutdown")
+	}
+	return nil
 }
 
 // drainOutcome classifies how a termination handler finished, which decides both
@@ -238,6 +244,10 @@ func classifyDrain(handlerErr, ctxErr error) drainOutcome {
 	case handlerErr == nil:
 		return drainSucceeded
 	case ctxErr != nil:
+		// Deliberate trade-off: a handler that failed on its own merits at the
+		// same instant a SIGINT/SIGTERM arrived is reported as an interrupt, not a
+		// failure. exec.CommandContext's kill error is indistinguishable from the
+		// child's own non-zero exit, and the race window is narrow.
 		return drainInterrupted
 	default:
 		return drainFailed

--- a/cmd/lifecycled/main_test.go
+++ b/cmd/lifecycled/main_test.go
@@ -3,8 +3,59 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
+
+	"github.com/buildkite/lifecycled"
+	"github.com/sirupsen/logrus"
 )
+
+// fakeNotice is a TerminationNotice whose Handle returns a preset error,
+// ignoring the handler, so handleNotice's exit-code wiring can be tested.
+type fakeNotice struct{ err error }
+
+func (fakeNotice) Type() string { return "fake" }
+
+func (n fakeNotice) Handle(context.Context, lifecycled.Handler, *logrus.Entry) error {
+	return n.err
+}
+
+func TestHandleNotice(t *testing.T) {
+	handlerErr := errors.New("handler failed")
+	tests := []struct {
+		name      string
+		noticeErr error
+		cancel    bool
+		wantErr   bool
+	}{
+		{"success returns nil", nil, false, false},
+		{"failure returns error for non-zero exit", handlerErr, false, true},
+		// A drain cancelled by our own shutdown is clean, so it must not exit non-zero.
+		{"shutdown-cancelled drain returns nil", handlerErr, true, false},
+	}
+
+	logger := logrus.New()
+	logger.Out = io.Discard
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancel {
+				cancel()
+			}
+
+			err := handleNotice(ctx, fakeNotice{err: tc.noticeErr}, nil, logrus.NewEntry(logger))
+			if tc.wantErr {
+				if !errors.Is(err, handlerErr) {
+					t.Errorf("handleNotice() = %v, want %v", err, handlerErr)
+				}
+			} else if err != nil {
+				t.Errorf("handleNotice() = %v, want nil", err)
+			}
+		})
+	}
+}
 
 func TestClassifyDrain(t *testing.T) {
 	handlerErr := errors.New("handler failed")

--- a/cmd/lifecycled/main_test.go
+++ b/cmd/lifecycled/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -10,13 +11,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// fakeNotice is a TerminationNotice whose Handle returns a preset error,
-// ignoring the handler, so handleNotice's exit-code wiring can be tested.
+// fakeNotice is a TerminationNotice whose Handle returns a preset error, ignoring
+// the handler, so handleNotice's exit-code wiring can be tested. It mirrors the
+// real Handle contract: a handler error observed while ctx is cancelled is marked
+// ErrDrainInterrupted.
 type fakeNotice struct{ err error }
 
 func (fakeNotice) Type() string { return "fake" }
 
-func (n fakeNotice) Handle(context.Context, lifecycled.Handler, *logrus.Entry) error {
+func (n fakeNotice) Handle(ctx context.Context, _ lifecycled.Handler, _ *logrus.Entry) error {
+	if n.err != nil && ctx.Err() != nil {
+		return fmt.Errorf("%w: %w", lifecycled.ErrDrainInterrupted, n.err)
+	}
 	return n.err
 }
 
@@ -62,20 +68,20 @@ func TestClassifyDrain(t *testing.T) {
 	tests := []struct {
 		name       string
 		handlerErr error
-		ctxErr     error
 		want       drainOutcome
 	}{
-		{"success", nil, nil, drainSucceeded},
-		// A handler that returns nil is a success even if ctx was cancelled.
-		{"success despite cancellation", nil, context.Canceled, drainSucceeded},
-		{"failure", handlerErr, nil, drainFailed},
-		{"interrupted by shutdown", handlerErr, context.Canceled, drainInterrupted},
+		{"success", nil, drainSucceeded},
+		{"failure", handlerErr, drainFailed},
+		// Only an error Handle marked as interrupted is a clean shutdown; a bare
+		// handler error, even one wrapping context.Canceled, is a genuine failure.
+		{"unmarked cancellation is failure", fmt.Errorf("%w: %w", context.Canceled, handlerErr), drainFailed},
+		{"interrupted by shutdown", fmt.Errorf("%w: %w", lifecycled.ErrDrainInterrupted, handlerErr), drainInterrupted},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := classifyDrain(tc.handlerErr, tc.ctxErr); got != tc.want {
-				t.Errorf("classifyDrain(%v, %v) = %d, want %d", tc.handlerErr, tc.ctxErr, got, tc.want)
+			if got := classifyDrain(tc.handlerErr); got != tc.want {
+				t.Errorf("classifyDrain(%v) = %d, want %d", tc.handlerErr, got, tc.want)
 			}
 		})
 	}

--- a/cmd/lifecycled/main_test.go
+++ b/cmd/lifecycled/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestClassifyDrain(t *testing.T) {
+	handlerErr := errors.New("handler failed")
+	tests := []struct {
+		name       string
+		handlerErr error
+		ctxErr     error
+		want       drainOutcome
+	}{
+		{"success", nil, nil, drainSucceeded},
+		// A handler that returns nil is a success even if ctx was cancelled.
+		{"success despite cancellation", nil, context.Canceled, drainSucceeded},
+		{"failure", handlerErr, nil, drainFailed},
+		{"interrupted by shutdown", handlerErr, context.Canceled, drainInterrupted},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyDrain(tc.handlerErr, tc.ctxErr); got != tc.want {
+				t.Errorf("classifyDrain(%v, %v) = %d, want %d", tc.handlerErr, tc.ctxErr, got, tc.want)
+			}
+		})
+	}
+}

--- a/daemon.go
+++ b/daemon.go
@@ -164,6 +164,13 @@ type TerminationNotice interface {
 	Handle(context.Context, Handler, *logrus.Entry) error
 }
 
+// ErrDrainInterrupted marks a handler error caused by the daemon's own
+// SIGINT/SIGTERM cancelling the drain rather than a genuine handler failure.
+// Handle wraps the handler error with it, captured when the handler returns, so
+// the outcome is fixed before any detached cleanup (e.g. CompleteLifecycleAction)
+// can widen the cancellation window and relabel a real failure as an interrupt.
+var ErrDrainInterrupted = errors.New("drain interrupted by shutdown")
+
 // Handler ...
 type Handler interface {
 	Execute(ctx context.Context, args ...string) error

--- a/daemon.go
+++ b/daemon.go
@@ -76,13 +76,14 @@ func (c *Config) Validate() error {
 	if !c.SpotListener && c.SNSTopic == "" {
 		return errors.New("no listeners enabled: set --sns-topic and/or drop --no-spot")
 	}
+	var errs []error
 	if c.SpotListener && c.SpotListenerInterval <= 0 {
-		return fmt.Errorf("--spot-listener-interval must be positive, got %s", c.SpotListenerInterval)
+		errs = append(errs, fmt.Errorf("--spot-listener-interval must be positive, got %s", c.SpotListenerInterval))
 	}
 	if c.SNSTopic != "" && c.AutoscalingHeartbeatInterval <= 0 {
-		return fmt.Errorf("--autoscaling-heartbeat-interval must be positive, got %s", c.AutoscalingHeartbeatInterval)
+		errs = append(errs, fmt.Errorf("--autoscaling-heartbeat-interval must be positive, got %s", c.AutoscalingHeartbeatInterval))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // Daemon is what orchestrates the listening and execution of the handler on a termination notice.

--- a/daemon.go
+++ b/daemon.go
@@ -68,6 +68,23 @@ type Config struct {
 	AutoscalingHeartbeatInterval time.Duration
 }
 
+// Validate rejects configuration that would otherwise fail at runtime: a
+// non-positive listener interval panics time.NewTicker (the autoscaling one only
+// when a termination notice arrives), and a daemon with no listeners blocks
+// forever doing nothing.
+func (c *Config) Validate() error {
+	if !c.SpotListener && c.SNSTopic == "" {
+		return errors.New("no listeners enabled: set --sns-topic and/or drop --no-spot")
+	}
+	if c.SpotListener && c.SpotListenerInterval <= 0 {
+		return fmt.Errorf("--spot-listener-interval must be positive, got %s", c.SpotListenerInterval)
+	}
+	if c.SNSTopic != "" && c.AutoscalingHeartbeatInterval <= 0 {
+		return fmt.Errorf("--autoscaling-heartbeat-interval must be positive, got %s", c.AutoscalingHeartbeatInterval)
+	}
+	return nil
+}
+
 // Daemon is what orchestrates the listening and execution of the handler on a termination notice.
 type Daemon struct {
 	instanceID string

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -253,6 +253,61 @@ func TestDaemon(t *testing.T) {
 
 }
 
+func TestConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  lifecycled.Config
+		wantErr string
+	}{
+		{
+			name:   "spot listener with a valid interval",
+			config: lifecycled.Config{SpotListener: true, SpotListenerInterval: time.Second},
+		},
+		{
+			name:   "autoscaling listener with a valid interval",
+			config: lifecycled.Config{SNSTopic: "topic", AutoscalingHeartbeatInterval: time.Second},
+		},
+		{
+			name:    "no listeners enabled",
+			config:  lifecycled.Config{},
+			wantErr: "no listeners enabled",
+		},
+		{
+			name:    "spot interval not positive",
+			config:  lifecycled.Config{SpotListener: true, SpotListenerInterval: 0},
+			wantErr: "spot-listener-interval",
+		},
+		{
+			name:    "heartbeat interval not positive",
+			config:  lifecycled.Config{SNSTopic: "topic", AutoscalingHeartbeatInterval: -time.Second},
+			wantErr: "autoscaling-heartbeat-interval",
+		},
+		{
+			// A disabled listener's interval is irrelevant and must not fail validation.
+			name:   "disabled spot listener ignores its interval",
+			config: lifecycled.Config{SNSTopic: "topic", AutoscalingHeartbeatInterval: time.Second, SpotListenerInterval: 0},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
 func parseTagString(tagString string) map[string]string {
 	tags := make(map[string]string)
 

--- a/daemon_test.go
+++ b/daemon_test.go
@@ -255,9 +255,9 @@ func TestDaemon(t *testing.T) {
 
 func TestConfigValidate(t *testing.T) {
 	tests := []struct {
-		name    string
-		config  lifecycled.Config
-		wantErr string
+		name     string
+		config   lifecycled.Config
+		wantErrs []string
 	}{
 		{
 			name:   "spot listener with a valid interval",
@@ -268,19 +268,30 @@ func TestConfigValidate(t *testing.T) {
 			config: lifecycled.Config{SNSTopic: "topic", AutoscalingHeartbeatInterval: time.Second},
 		},
 		{
-			name:    "no listeners enabled",
-			config:  lifecycled.Config{},
-			wantErr: "no listeners enabled",
+			name:     "no listeners enabled",
+			config:   lifecycled.Config{},
+			wantErrs: []string{"no listeners enabled"},
 		},
 		{
-			name:    "spot interval not positive",
-			config:  lifecycled.Config{SpotListener: true, SpotListenerInterval: 0},
-			wantErr: "spot-listener-interval",
+			name:     "spot interval not positive",
+			config:   lifecycled.Config{SpotListener: true, SpotListenerInterval: 0},
+			wantErrs: []string{"spot-listener-interval"},
 		},
 		{
-			name:    "heartbeat interval not positive",
-			config:  lifecycled.Config{SNSTopic: "topic", AutoscalingHeartbeatInterval: -time.Second},
-			wantErr: "autoscaling-heartbeat-interval",
+			name:     "spot interval negative",
+			config:   lifecycled.Config{SpotListener: true, SpotListenerInterval: -time.Second},
+			wantErrs: []string{"spot-listener-interval"},
+		},
+		{
+			name:     "heartbeat interval not positive",
+			config:   lifecycled.Config{SNSTopic: "topic", AutoscalingHeartbeatInterval: -time.Second},
+			wantErrs: []string{"autoscaling-heartbeat-interval"},
+		},
+		{
+			// Both listeners misconfigured: Validate reports both, not just the first.
+			name:     "both intervals not positive",
+			config:   lifecycled.Config{SpotListener: true, SpotListenerInterval: 0, SNSTopic: "topic", AutoscalingHeartbeatInterval: 0},
+			wantErrs: []string{"spot-listener-interval", "autoscaling-heartbeat-interval"},
 		},
 		{
 			// A disabled listener's interval is irrelevant and must not fail validation.
@@ -292,17 +303,19 @@ func TestConfigValidate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.config.Validate()
-			if tc.wantErr == "" {
+			if len(tc.wantErrs) == 0 {
 				if err != nil {
 					t.Fatalf("Validate() = %v, want nil", err)
 				}
 				return
 			}
 			if err == nil {
-				t.Fatalf("Validate() = nil, want an error containing %q", tc.wantErr)
+				t.Fatalf("Validate() = nil, want an error containing %q", tc.wantErrs)
 			}
-			if !strings.Contains(err.Error(), tc.wantErr) {
-				t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), want)
+				}
 			}
 		})
 	}

--- a/spot.go
+++ b/spot.go
@@ -118,5 +118,9 @@ func (n *spotTerminationNotice) Type() string {
 }
 
 func (n *spotTerminationNotice) Handle(ctx context.Context, handler Handler, _ *logrus.Entry) error {
-	return handler.Execute(ctx, n.transition, n.instanceID, n.terminationTime.Format(time.RFC3339))
+	err := handler.Execute(ctx, n.transition, n.instanceID, n.terminationTime.Format(time.RFC3339))
+	if err != nil && ctx.Err() != nil {
+		return fmt.Errorf("%w: %w", ErrDrainInterrupted, err)
+	}
+	return err
 }


### PR DESCRIPTION
## Summary

Startup and shutdown hardening for the lifecycled daemon, plus operator-facing notes in the README.

## What changed

Config is now validated at startup (`Config.Validate()`): a non-positive `--spot-listener-interval` or `--autoscaling-heartbeat-interval` is rejected with a clear fatal message rather than panicking `time.NewTicker` later. The autoscaling ticker isn't built until a termination notice arrives, so today that panic would land mid-termination, after the daemon has run fine for hours. A run with no listeners enabled (`--no-spot` and no `--sns-topic`) now fails fast instead of blocking forever doing nothing. When more than one interval is invalid, all of them are reported at once rather than only the first.

A failed drain handler now propagates its error so the process exits non-zero. Previously the error was logged and then immediately followed by a "Handler finished successfully" line while the process still exited 0. A SIGINT/SIGTERM that cancels a drain mid-flight is treated as a clean shutdown, not a failure, so it still exits 0; only a handler that fails on its own merits exits non-zero. This outcome-to-exit-code wiring is now covered by a test so it can't silently regress.

The README gains a few notes: that autoscaling notices are handled at most once (a mid-drain crash isn't resumed on restart, unlike spot terminations, which are re-read from instance metadata), that the heartbeat interval should stay shorter than the hook's `HeartbeatTimeout`, and a new "Exit codes and restarts" section describing the exit-code contract and how `Restart=on-failure` interacts with each notice type.

## Testing

`go build`, `go vet`, and `golangci-lint` are clean and the full suite passes. Adds `TestConfigValidate` (including negative and dual-invalid intervals) and `TestHandleNotice` (the drain exit-code wiring). The fatal-startup paths were verified end-to-end with the binary: zero/negative intervals via both the flag and the `LIFECYCLED_*` env var, and the no-listeners case, all exit 1.