### PR TITLE
Tolerate AccessDenied on CreateLogStream

### DIFF
--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -41,10 +41,14 @@ func NewCloudWatchLogsHook(ctx context.Context, client CloudWatchLogsClient, gro
 	}); err != nil && !alreadyExists(err) && !accessDenied(err) {
 		return nil, err
 	}
+	// CreateLogStream is also best-effort against AccessDenied so a least-privilege
+	// role with only logs:PutLogEvents against a pre-provisioned stream isn't fatal.
+	// A genuinely missing stream we can't create then surfaces per-line in Fire
+	// rather than at startup.
 	if _, err := client.CreateLogStream(ctx, &cloudwatchlogs.CreateLogStreamInput{
 		LogGroupName:  aws.String(groupName),
 		LogStreamName: aws.String(streamName),
-	}); err != nil && !alreadyExists(err) {
+	}); err != nil && !alreadyExists(err) && !accessDenied(err) {
 		return nil, err
 	}
 	return &CloudWatchLogsHook{client: client, groupName: groupName, streamName: streamName}, nil

--- a/cloudwatch_test.go
+++ b/cloudwatch_test.go
@@ -77,6 +77,12 @@ func TestNewCloudWatchLogsHook(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			// A pre-provisioned stream + a role without logs:CreateLogStream must not
+			// be fatal, mirroring the group tolerance above.
+			name:      "tolerates access denied on stream",
+			streamErr: &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "no perms"},
+		},
+		{
 			name:      "propagates other stream errors",
 			streamErr: errors.New("access denied"),
 			wantErr:   true,


### PR DESCRIPTION
## Summary

Make the CloudWatch Logs hook tolerate `AccessDenied` on `CreateLogStream`, so a least-privilege role works against a pre-provisioned stream.

## What changed

`NewCloudWatchLogsHook` already treats `AccessDenied` on `CreateLogGroup` as non-fatal, since log groups are commonly provisioned out of band (e.g. Terraform). `CreateLogStream` did not get the same tolerance, so a role granted only `logs:PutLogEvents` against an existing group and stream failed fatally at startup.

`CreateLogStream` now applies the same `accessDenied` check. A genuinely missing stream that the daemon can't create surfaces per-line in `Fire` (logged to stderr) rather than at startup, which mirrors the existing group behavior.

## Testing

`go build`, `go vet`, and `golangci-lint` are clean and the full suite passes. Adds a `TestNewCloudWatchLogsHook` case that a `CreateLogStream` `AccessDeniedException` is tolerated, alongside the existing case confirming other stream errors still propagate.