### PR TITLE
Parse queue name from path in queue-cleaner

### DIFF
--- a/tools/lifecycled-queue-cleaner/main.go
+++ b/tools/lifecycled-queue-cleaner/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"log"
-	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -259,8 +258,6 @@ func listQueues(ctx context.Context, client SQSClient) ([]string, error) {
 	return urls, nil
 }
 
-var queueRegex = regexp.MustCompile(`^https://sqs\.(.+?)\.amazonaws\.com(?:\.cn)?/(.+?)/lifecycled-(i-.+)$`)
-
 func listInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *ec2.Client) ([]string, error) {
 	instances, err := listInstances(ctx, ec2Client)
 	if err != nil {
@@ -289,16 +286,32 @@ func listInactiveQueues(ctx context.Context, sqsClient *sqs.Client, ec2Client *e
 	return inactiveQueues, nil
 }
 
+// instanceIDFromQueueURL returns the EC2 instance id encoded in a lifecycled
+// queue URL (.../<account>/lifecycled-<instanceID>) and whether the URL follows
+// that scheme. It reads the queue name from the final path segment, so it works
+// across every SQS endpoint (standard, GovCloud, China, FIPS, dualstack) without
+// matching the hostname.
+func instanceIDFromQueueURL(queueURL string) (string, bool) {
+	name := queueURL[strings.LastIndex(queueURL, "/")+1:]
+	id, ok := strings.CutPrefix(name, "lifecycled-")
+	if !ok {
+		return "", false
+	}
+	if rest, ok := strings.CutPrefix(id, "i-"); !ok || rest == "" {
+		return "", false
+	}
+	return id, true
+}
+
 // filterInactiveQueues returns the lifecycled- queue URLs whose instance id is
-// not in running. URLs that don't match the lifecycled- naming scheme are ignored.
+// not in running. URLs that don't follow the lifecycled- naming scheme are ignored.
 func filterInactiveQueues(urls []string, running map[string]struct{}) []string {
 	var inactive []string
 	for _, queue := range urls {
-		matches := queueRegex.FindStringSubmatch(queue)
-		if len(matches) != 4 {
+		instanceID, ok := instanceIDFromQueueURL(queue)
+		if !ok {
 			continue
 		}
-		instanceID := matches[3]
 		if _, exists := running[instanceID]; !exists {
 			inactive = append(inactive, queue)
 		}

--- a/tools/lifecycled-queue-cleaner/main_test.go
+++ b/tools/lifecycled-queue-cleaner/main_test.go
@@ -18,10 +18,13 @@ import (
 
 func TestFilterInactiveQueues(t *testing.T) {
 	const (
-		dead    = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-dead"
-		running = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-running"
-		other   = "https://sqs.us-east-1.amazonaws.com/123456789012/some-other-queue"
-		chinaCN = "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/lifecycled-i-dead"
+		dead      = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-dead"
+		running   = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-running"
+		other     = "https://sqs.us-east-1.amazonaws.com/123456789012/some-other-queue"
+		chinaCN   = "https://sqs.cn-north-1.amazonaws.com.cn/123456789012/lifecycled-i-dead"
+		fips      = "https://sqs-fips.us-east-1.amazonaws.com/123456789012/lifecycled-i-dead"
+		dualstack = "https://sqs.us-east-1.api.aws/123456789012/lifecycled-i-dead"
+		emptyID   = "https://sqs.us-east-1.amazonaws.com/123456789012/lifecycled-i-"
 	)
 	runningSet := map[string]struct{}{"i-running": {}}
 
@@ -34,7 +37,10 @@ func TestFilterInactiveQueues(t *testing.T) {
 		{name: "keeps queue for terminated instance", urls: []string{dead}, want: []string{dead}},
 		{name: "skips queue for running instance", urls: []string{running}, want: nil},
 		{name: "ignores non-lifecycled queue", urls: []string{other}, want: nil},
+		{name: "ignores queue with no instance id", urls: []string{emptyID}, want: nil},
 		{name: "matches china partition url", urls: []string{chinaCN}, want: []string{chinaCN}},
+		{name: "matches fips endpoint url", urls: []string{fips}, want: []string{fips}},
+		{name: "matches dualstack endpoint url", urls: []string{dualstack}, want: []string{dualstack}},
 		{name: "mixed", urls: []string{dead, running, other}, want: []string{dead}},
 	}
 


### PR DESCRIPTION
## Summary

Make `lifecycled-queue-cleaner` identify queues by parsing the queue name from the URL path instead of matching the SQS hostname, so it covers every endpoint flavor.

## What changed

The cleaner extracted the instance id with a hostname regex anchored to `sqs.<region>.amazonaws.com(.cn)?`, which matched standard, GovCloud, and China URLs but silently skipped FIPS (`sqs-fips.<region>.amazonaws.com`) and dualstack (`sqs.<region>.api.aws`). Under `AWS_USE_FIPS_ENDPOINT=true` the queues lifecycled creates carry `sqs-fips` hostnames, so the cleaner would never delete them and inactive queues would accumulate. (The regex was anchored and instance-gated, so the failure mode was only leaked queues, never deleting a live one.)

The queue name is always the last path segment (`/<account>/lifecycled-<instanceID>`) regardless of endpoint, and `listQueues` already filters on the `lifecycled-` prefix. The new `instanceIDFromQueueURL` reads the instance id from that last segment, which is endpoint-agnostic and drops the hostname regex (and the `regexp` import) entirely, so it's a net simplification.

## Testing

`go build`, `go vet`, and `golangci-lint` are clean and the full suite passes. `TestFilterInactiveQueues` gains FIPS and dualstack cases plus a guard that a `lifecycled-i-` queue with no instance id is ignored; the existing standard/China cases still pass.